### PR TITLE
Refactor BattleCardEffects; abstracted target logic

### DIFF
--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/effects/BattleCardEffect.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/effects/BattleCardEffect.py
@@ -24,20 +24,30 @@ class BattleCardEffect:
         self.buffs: List[CardBuff]
         self.buffs = []
 
+    def on_activation(self, target, turns_queue):
+        """
+        Effect logic abstract method.
+        One should override it and write the logic here.
+        @param target: Target affected by this effect - BattlePlayer instance
+        @param turns_queue: TurnsQueue instance.
+        """
+        pass
+
     def activate(self,
                  card_owner,
                  other_player,
                  turns_queue):
         """
-        This method should be overridden.
-        By calling this method this effect will perform its logic.
+        Triggers the effect.
+        It essentially calls on_activation method that should be overridden to one's liking.
         @param card_owner: BattlePlayer instance.
         @param other_player: BattlePlayer instance.
         @param turns_queue: Queue of players' turns, can be changed by some effects.
         @return:
         """
 
-        pass
+        selected_target = self.choose_target(card_owner, other_player)
+        self.on_activation(selected_target, turns_queue)
 
     def choose_target(self, card_owner, other_player):
         """

--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/effects/DmgEffect.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/effects/DmgEffect.py
@@ -11,14 +11,10 @@ class DmgEffect(BattleCardEffect):
     def __init__(self, effect_model: CardLevelEffects):
         super(DmgEffect, self).__init__(effect_model)
 
-    def activate(self,
-                 card_owner,
-                 other_player,
-                 turns_queue):
+    def on_activation(self, target, turns_queue):
         calculator = BattleCalculator.get_instance()
 
         dmg = calculator.calculate_effect_power(self.power, self.range, self.buffs)
 
-        dmg_receiver = self.choose_target(card_owner, other_player)
 
-        dmg_receiver.statistics.deal_damage(dmg)
+        target.statistics.deal_damage(dmg)


### PR DESCRIPTION
Zrobiłem refactor klas odpowiedzialnych za efekty.
Metoda activate() nie jest już abstrakcyjna - zamknięta jest tam logika wyboru targetu. Dodatkowo wywołuję nową metodę on_activation(), która jest abstrakcyjna. Logikę efektu będziemy teraz pisać nadpisując metodę on_activation, a nie activate. Tam mamy już gotowy target jako parametr.
Nie implementowałem rozwiązania zasugerowanego przez @Michael-Czekanski (target jako lista), bo stwierdziłem że to jest zbyt duży edge case kiedy to mogłoby być potrzebne, a skomplikuje wywoływania funkcji bo będzie trzeba iterować. Jeżeli w przyszłości wystąpi taka sytuacja, że efekt miałby robić coś wielu celom, możemy po prostu stworzyć dodatkowe instancje z efektem.