### PR TITLE
Poprawiono błędy z eslinta, wyłączono sprawdzanie propsType

### DIFF
--- a/WMIAdventure/frontend/.eslintrc.js
+++ b/WMIAdventure/frontend/.eslintrc.js
@@ -1,22 +1,29 @@
-// module.exports = {
-//     "env": {
-//         "browser": true,
-//         "es2021": true
-//     },
-//     "extends": [
-//         "eslint:recommended",
-//         "plugin:react/recommended"
-//     ],
-//     "parserOptions": {
-//         "ecmaFeatures": {
-//             "jsx": true
-//         },
-//         "ecmaVersion": 12,
-//         "sourceType": "module"
-//     },
-//     "plugins": [
-//         "react"
-//     ],
-//     "rules": {
-//     }
-// };
+module.exports = {
+    env: {
+      commonjs: true,
+      node: true,
+      browser: true,
+      es6: true,
+      jest: true,
+    },
+    extends: ["eslint:recommended", "plugin:react/recommended"],
+    globals: {},
+    parser: "babel-eslint",
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+      ecmaVersion: 2018,
+      sourceType: "module",
+    },
+    plugins: ["react", "import", "react-hooks"],
+    ignorePatterns: ["node_modules/"],
+    rules: {
+        "react/prop-types": "off"
+    },
+    settings: {
+      react: {
+        version: "latest", // "detect" automatically picks the version you have installed.
+      },
+    },
+  };

--- a/WMIAdventure/frontend/src/js/App.jsx
+++ b/WMIAdventure/frontend/src/js/App.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {Route, Switch} from 'react-router-dom';
 import MainMenu from './pages/entertainment/MainMenu';
 import Profile from './pages/entertainment/Profile';


### PR DESCRIPTION
Poprawiłem plik eslinrec.js, wyłączając przy tym sprawdzanie propsType (jest to rzecz, która nie jest błędem, ale jeśli chcecie, to mogę to poprawić, żeby było zgodnie z wytycznymi airbnb). 
Aktualnie komenda ./node_modules/.bin/eslint . nie zwraca błędów. Poprawiłem też plik App.js, zmieniając go na App,jsx (forsowany ostatnio przez FaceBooka i AIRBNB format plików reactowych). 