### PR TITLE
Battle simulation empower card

### DIFF
--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/BattleCard.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/BattleCard.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 from battle.businesslogic.effects.Effect import Effect
 from battle.businesslogic.effects.EffectFactory import EffectFactory
@@ -37,7 +37,7 @@ class BattleCard:
         for effect in self.effects:
             effect.update()
 
-    def assign_buff(self, buff: Buff, effect_type: CardEffect.EffectId):
+    def assign_buff(self, buff: Buff, effect_type: Union[CardEffect.EffectId, None] = None):
         """
         This method assigns a buff to this card's appropriate effects.
         @param: buff - Buff instance
@@ -45,5 +45,7 @@ class BattleCard:
         """
         for effect in self.effects:
             # We check if any of the effects if of the type specified in the parameter
-            if effect.effect_model.card_effect.EffectId is effect_type:
+            # If we specified none, it applies to all effect types.
+            card_type = effect.effect_model.card_effect.id
+            if effect_type is None or card_type == effect_type:
                 effect.add_buff(buff)

--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/effects/EmpowerCardEffect.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/effects/EmpowerCardEffect.py
@@ -1,0 +1,28 @@
+from typing import Union
+
+from battle.businesslogic.Buff import Buff
+from battle.businesslogic.Calculator import Calculator
+from battle.businesslogic.Player import Player
+from battle.businesslogic.effects.Effect import Effect
+from cards.models import CardLevelEffects, CardEffect
+
+
+class EmpowerCardEffect(Effect):
+    """
+    Generic card empowering.
+    Adds a modifier to the next card.
+    """
+    target_effect: Union[CardEffect.EffectId, None]
+
+    def __init__(self, effect_model: CardLevelEffects, target_effect: Union[CardEffect.EffectId, None] = None):
+        self.target_effect = target_effect
+        super().__init__(effect_model)
+
+    def on_activation(self, target: Player, turns_queue):
+        calculator = Calculator.get_instance()
+        emp_ammount = calculator.calculate_effect_power(self.power, self.range, self.buffs)
+
+        card_to_buff = target.deck.lookup()
+
+        buff = Buff(modifier=emp_ammount)
+        card_to_buff.assign_buff(buff, self.target_effect)

--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/effects/tests_EmpowerCardEffect.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/effects/tests_EmpowerCardEffect.py
@@ -1,0 +1,55 @@
+from unittest import TestCase
+
+from battle.businesslogic.effects.EmpowerCardEffect import EmpowerCardEffect
+from cards.models import CardLevelEffects, CardEffect
+from battle.businesslogic.tests.Creator import Creator
+from battle.businesslogic.Deck import Deck
+from battle.businesslogic.Player import Player
+
+
+class EmpowerCardEffectTestCase(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.creator = Creator()
+
+        cls.u1 = cls.creator.get_user_models()[0]
+        cls.d1 = cls.creator.get_decks()[0]
+        cls.card_owner = Player(cls.u1.id, Deck(cls.d1))
+        card_effect_info_model = CardEffect.objects.get(id=CardEffect.EffectId.SKIP)
+
+        target = CardLevelEffects.Target.PLAYER
+
+        cls.effect_model = CardLevelEffects.objects.create(
+            card=cls.creator.get_cards()[0],
+            card_effect=card_effect_info_model,
+            target=target,
+            power=20.0,
+            range=0.0
+        )
+
+    def setUp(self) -> None:
+        self.card_owner = Player(self.u1.id, Deck(self.d1))
+
+    def test_empower_any(self):
+        effect_any = EmpowerCardEffect(self.effect_model)
+        effect_any.on_activation(self.card_owner, None)
+        affected_card = self.card_owner.deck.lookup()
+
+        # We check whether the effect got assigned properly
+        affected_effect = affected_card.effects[0]
+        self.assertEqual(len(affected_effect.buffs), 1)
+
+    def test_empower_specific(self):
+        next_card_effect_id = self.card_owner.deck.lookup(0).effects[0].effect_model.card_effect.id
+        effect_specific_to_next_card = EmpowerCardEffect(self.effect_model, CardEffect.EffectId(next_card_effect_id))
+        effect_specific_to_next_card.on_activation(self.card_owner, None)
+
+        affected_card = self.card_owner.deck.lookup()
+
+        affected_effect = affected_card.effects[0]
+        self.assertEqual(len(affected_effect.buffs), 1)
+
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.creator.perform_deletion()


### PR DESCRIPTION
Zaimplementowałem ten efekt z myślą, że przy tworzeniu go w konstruktorze podamy ID efektu jako parametr, do którego to wzmocnienie ma się przyczepić. Może być None, to wtedy do dowolnego. Problem polega na tym, jak to serializować? Do tej pory w modelu nie ma mowy o czymś takim. Masz jakiś pomysł jak to przełożyć na modele i widoki?

Closes #136