### PR TITLE
Battle simulation double card effect

### DIFF
--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/effects/TwoTimesExecuteEffect.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/effects/TwoTimesExecuteEffect.py
@@ -1,0 +1,21 @@
+from battle.businesslogic.Player import Player
+from battle.businesslogic.effects.Effect import Effect
+
+
+class TwoTimesExecuteEffect(Effect):
+    """
+    One may say that this effect 'duplicates' the card, so the card gets used two times
+    in two consecutive player turns, but it does not duplicate itself in a way that there are
+    two instances of the card in the deck. Actual behavior is just that it gets executed twice, hence the name.
+    """
+
+    def on_activation(self, target: Player, turns_queue):
+        deck = target.deck
+        next_card = deck.lookup()
+
+        # If we were do to it like this:
+        # deck.cards_queue.appendleft(next_card)
+        # The card would get permanently duplicated, and the deck would be larger than 5.
+        # We need some mechanism to remove appended card from the deck after it gets used.
+
+        deck.temp_cards_queue.append(next_card)

--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/effects/tests_TwoTimesExecuteEffect.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/effects/tests_TwoTimesExecuteEffect.py
@@ -1,0 +1,51 @@
+from unittest import TestCase
+
+from battle.businesslogic.Deck import Deck
+from battle.businesslogic.Player import Player
+from battle.businesslogic.effects.TwoTimesExecuteEffect import TwoTimesExecuteEffect
+from battle.businesslogic.tests.Creator import Creator
+from cards.models import CardEffect, CardLevelEffects
+
+
+class TwoTimesExecuteEffectTestCase(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.creator = Creator()
+
+        u1 = cls.creator.get_user_models()[0]
+        d1 = cls.creator.get_decks()[0]
+        cls.card_owner = Player(u1.id, Deck(d1))
+        card_effect_info_model = CardEffect.objects.get(id=CardEffect.EffectId.DOUBLEACTION)
+
+        target = CardLevelEffects.Target.PLAYER
+
+        cls.effect_model = CardLevelEffects.objects.create(
+            card=cls.creator.get_cards()[0],
+            card_effect=card_effect_info_model,
+            target=target,
+            power=None,
+            range=None
+        )
+
+    def setUp(self) -> None:
+        self.effect = TwoTimesExecuteEffect(self.effect_model)
+
+    def test_integration_with_deck(self):
+        # This card executes the effect
+        top_card = self.card_owner.deck.get_card()
+        self.effect.on_activation(self.card_owner, None)
+
+        # Next two cards should be identical, and the first one should not be the same as the first.
+        top_card_after = self.card_owner.deck.get_card()
+        self.assertIsNot(top_card, top_card_after)
+
+        second_card = self.card_owner.deck.get_card()
+        self.assertIs(top_card_after, second_card)
+
+        # This one should be different
+        third_card = self.card_owner.deck.get_card()
+        self.assertIsNot(top_card, third_card)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.creator.perform_deletion()

--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/effects/tests_TwoTimesExecuteEffect.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/effects/tests_TwoTimesExecuteEffect.py
@@ -32,19 +32,19 @@ class TwoTimesExecuteEffectTestCase(TestCase):
 
     def test_integration_with_deck(self):
         # This card executes the effect
-        top_card = self.card_owner.deck.get_card()
+        card_with_effect = self.card_owner.deck.get_card()
         self.effect.on_activation(self.card_owner, None)
 
-        # Next two cards should be identical, and the first one should not be the same as the first.
-        top_card_after = self.card_owner.deck.get_card()
-        self.assertIsNot(top_card, top_card_after)
-
+        # Next card can't be the same one as the one that held the effect
+        first_card = self.card_owner.deck.get_card()
+        self.assertIsNot(card_with_effect, first_card)
+        # Next card has to be the same as the previous one
         second_card = self.card_owner.deck.get_card()
-        self.assertIs(top_card_after, second_card)
+        self.assertIs(first_card, second_card)
 
         # This one should be different
         third_card = self.card_owner.deck.get_card()
-        self.assertIsNot(top_card, third_card)
+        self.assertIsNot(first_card, third_card)
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/tests_Deck.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/tests_Deck.py
@@ -1,3 +1,4 @@
+from copy import copy
 from typing import List
 from unittest import TestCase
 
@@ -46,9 +47,34 @@ class DeckTestCase(TestCase):
         # Assert card is inserted at the back of the cards queue when you retrieve it.
         self.assertIs(card, list(self.attacker_battle_deck.cards_queue)[-1])
 
+    def test_temp_deck_lookup(self):
+        deck = self.attacker_battle_deck
+        # We get a card from the middle of the deck
+        card4 = self.attacker_battle_deck.lookup(4)
+        # And we add it to temp_cards_queue
+        deck.temp_cards_queue.append(card4)
+
+        # If all went OK, we should get the previously appended card from the deck at front of the deck..
+
+        returned_card = deck.lookup()
+        self.assertIs(returned_card, card4)
+
+    def test_temp_deck_get(self):
+        deck = copy(self.attacker_battle_deck)
+        card4 = deck.lookup(4)
+        deck.temp_cards_queue.append(card4)
+
+        returned_card = deck.get_card()
+        self.assertIs(returned_card, card4)
+
     def test_size(self):
+        deck = self.attacker_battle_deck
         expected_size = 5
-        self.assertEqual(self.attacker_battle_deck.size(), expected_size)
+        self.assertEqual(deck.size(), expected_size)
+
+        expected_size_after_alteration = expected_size + 1
+        deck.temp_cards_queue.append(deck.lookup())
+        self.assertEqual(deck.size(), expected_size_after_alteration)
 
     @classmethod
     def tearDownClass(cls) -> None:


### PR DESCRIPTION
Closes #133 

Przy tym efekcie musiałem trochę nagrzebać - początkowo myślałem, że jeżeli karta miałaby wykonać się podwójnie, to wystarczy przecież dodać ją na początek kolejki. Ale wtedy ta karta zostanie na stałe w decku i będzie za każdym razem wykonywała się dwukrotnie.

Żeby rozwiązać ten problem zaimplementowałem kolejną kolejkę kart w Decku przechowującą karty, które znikną po użyciu.

Napisałem dobry test integracyjny do tego efektu i wszystko jest w porządku.

Ostatnia kwestia to ProcessRecorder. W obecnym rozwiązaniu karty znajdujące się w tymczasowym decku w ogóle nie są zapisywane. Główkowałem sporo jak to rozwiązać i zauważyłem, że jeżeli karta z góry decka ma wykonać się dwa razy, to tak naprawdę nasz deck się nie zmienia! Karta jest po prostu dwa razy na wierzchu i to dobrze.