### PR TITLE
Battle simulation stop player effect

### DIFF
--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/Player.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/Player.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from battle.businesslogic.effects.Effect import Effect
+from battle.businesslogic.player_states.PlayerState import PlayerState
 from .Deck import Deck
 from .Statistics import Statistics
 
@@ -11,6 +12,7 @@ class Player:
     It gets populated with model data.
     Has statistics that represent its current state and its card deck.
     """
+    states: List[PlayerState]
 
     def __init__(self, id: int, deck: Deck):
         """
@@ -23,6 +25,7 @@ class Player:
         self.deck = deck
 
         self.statistics = Statistics()
+        self.states = []
 
     def get_hp(self) -> int:
         return self.statistics.hp
@@ -33,5 +36,30 @@ class Player:
         @return: List of effects of proper card to be executed by battle simulation.
         """
 
+        self.__update__()
+
         card = self.deck.get_card()
-        return card.use()
+
+        for state in self.states:
+            card = state.player_uses_card(card)
+
+        if card is not None:
+            return card.use()
+        return []
+
+    def add_state(self, state: PlayerState):
+        self.states.append(state)
+
+    def __update__(self):
+        self.__update__states__()
+
+    def __update__states__(self):
+        for state in self.states:
+            state.update()
+
+        self.__remove__inactive_states__()
+
+    def __remove__inactive_states__(self):
+        for state in self.states:
+            if not state.active:
+                self.states.remove(state)

--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/effects/StopPlayerEffect.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/effects/StopPlayerEffect.py
@@ -1,0 +1,22 @@
+from battle.businesslogic.effects.Effect import Effect
+from battle.businesslogic.player_states.StoppedPlayerState import StoppedPlayerState
+from cards.models import CardLevelEffects
+
+
+class StopPlayerEffect(Effect):
+    """
+    Stops target player for given amount of turns.
+    """
+
+    def __init__(self, effect_model: CardLevelEffects, turns_stopped: int=1):
+        """
+
+        :param effect_model:
+        :param turns_stopped: For how many turns player should be stopped.
+        """
+
+        super().__init__(effect_model)
+        self.turns_stopped = turns_stopped
+
+    def on_activation(self, target, turns_queue):
+        target.add_state(StoppedPlayerState(self.turns_stopped))

--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/player_states/PlayerState.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/player_states/PlayerState.py
@@ -1,0 +1,22 @@
+class PlayerState:
+    """
+    Abstract PlayerState class.
+    """
+
+    def __init__(self, turns_active: int):
+        self.turns_active = turns_active
+        self.active = True
+
+    def update(self):
+        self.turns_active = max(0, self.turns_active - 1)
+        if self.turns_active <= 0:
+            self.active = False
+
+    def player_uses_card(self, card_to_use):
+        """
+        This method should be overridden in classes deriving from PlayerState class.
+        :param card_to_use: Card to be used by player.
+        :return: Modified card to be used or None.
+        """
+
+        return card_to_use

--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/player_states/StoppedPlayerState.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/player_states/StoppedPlayerState.py
@@ -1,0 +1,12 @@
+from battle.businesslogic.player_states.PlayerState import PlayerState
+
+
+class StoppedPlayerState(PlayerState):
+    def player_uses_card(self, card_to_use):
+        """
+        Stops player's turn by replacing card to use with None.
+        :param card_to_use: Card to be used.
+        :return: None - to disable player's turn.
+        """
+
+        return None


### PR DESCRIPTION
Wprowadziłem klasę *PlayerState*, działa ona podobnie jak Buffy dla Efektów.
Stany playera modyfikują używaną przez niego kartę poprzez abstrakcyjną metodę `player_uses_card(card_to_use)`.

Efekt StopPlayerEffect robi 
```python
target.add_state(StoppedPlayerState(1))
```
i zatrzymuje playera na jedną turę.

Coś takiego jak stany mogłoby być przydatne przy serializacji przebiegu walki dla frontendu.