### PR TITLE
Fixed: Failing unit tests

### DIFF
--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/Creator.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/Creator.py
@@ -188,7 +188,9 @@ class Creator:
         if card_level is None:
             card_level = CardLevel.objects.get(pk=1),
         card_info = CardInfo.objects.create(name=name, tooltip=tooltip)
+        self.infos.append(card_info)
         card = Card.objects.create(info=card_info, level=card_level)
+        self.cards.append(card)
         for card_effect_id, target, power, range_ in effects_data:
             card_effect = CardEffect.objects.get(id=card_effect_id)
             card.effects.create(card_effect=card_effect, target=target,

--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/Creator.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/Creator.py
@@ -174,7 +174,7 @@ class Creator:
 
     def create_card_model(self, effects_data: list[
         tuple[CardEffect.EffectId, CardLevelEffects.Target, Optional[int], Optional[float]]],
-                          name, card_level: CardLevel = CardLevel.objects.get(pk=1), tooltip="...") -> Card:
+                          name, card_level: CardLevel = None, tooltip="...") -> Card:
         """
         Creates Card model with given effects data.
 
@@ -184,6 +184,9 @@ class Creator:
         :param tooltip: Card tooltip.
         :return: Created Card model.
         """
+
+        if card_level is None:
+            card_level = CardLevel.objects.get(pk=1),
         card_info = CardInfo.objects.create(name=name, tooltip=tooltip)
         card = Card.objects.create(info=card_info, level=card_level)
         for card_effect_id, target, power, range_ in effects_data:
@@ -194,7 +197,7 @@ class Creator:
 
     def create_user_card(self, user_profile: UserProfile, effects_data: list[
         tuple[CardEffect.EffectId, CardLevelEffects.Target, Optional[int], Optional[float]]],
-                         name, card_level: CardLevel = CardLevel.objects.get(pk=1), tooltip="...") -> UserCard:
+                         name, card_level: CardLevel = None, tooltip="...") -> UserCard:
         """
         Creates UserCard object by creating Card model with given effects data and linking created Card
         with given UserProfile.
@@ -206,6 +209,8 @@ class Creator:
         :param tooltip: Card tooltip.
         :return: Created UserCard model.
         """
+        if card_level is None:
+            card_level = CardLevel.objects.get(pk=1)
         card = self.create_card_model(effects_data, name, card_level, tooltip)
         user_card = user_profile.user_cards.create(card=card)
         return user_card

--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/tests_BattleIntegration.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/tests_BattleIntegration.py
@@ -518,3 +518,6 @@ class BattleIntegrationTestCase(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.creator.perform_deletion()
+
+        cls.user1.delete()
+        cls.user2.delete()


### PR DESCRIPTION
Naprawiłem błąd z unitami.

Problem polegał na tym, że jako domyślną wartość zmiennej przypisywałeś wywołanie funkcji.
W Pythonie to trochę dziwnie działa, pokażę Ci przykładowy kod:
```python3
def g():
    print("Hello from G")

def f(data = g()):
    print("Hello from F")
```

Jak uruchomię ten kod, to nic nie powinno się wypisać, bo nie wywołuję nigdzie żadnej funkcji. A wypisuje się `Hello from G`.

W Pythonie przy uruchomieniu kodu wszystkie funkcje są przechowywane gdzieś w pamięci RAZEM z ich domyślnymi wartościami. To tak jakbyś miał statyczną zmienną w klasie. Tutaj domyślną wartością jest wywołanie funkcji g().