### PR TITLE
User deck view

### DIFF
--- a/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/serializers.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/serializers.py
@@ -1,8 +1,8 @@
-from abc import ABC
-
 from rest_framework import serializers
 
+from cards.models import Card
 from . import models
+from .models import UserProfile, Deck
 
 
 class UserProfileSerializer(serializers.ModelSerializer):
@@ -23,3 +23,47 @@ class UserProfileSerializer(serializers.ModelSerializer):
 
         newProfile.save()
         return newProfile
+
+
+class UserCardSerializer(serializers.ModelSerializer):
+    """
+    Serializes UserCard model.
+    Card is acquired from the UserCard model and serialized to bare minimum information.
+    """
+
+    # ID points to an ID of a CardInfo object
+    id = serializers.IntegerField(source='card.info.id')
+    level = serializers.IntegerField(source='card.level.level')
+
+    class Meta:
+        model = Card
+        fields = ['id', 'level']
+
+
+class DeckSerializer(serializers.ModelSerializer):
+    """
+    Serializes a deck.
+    We store each card separately with an index, because the order of them does matter.
+    deck_number is also stored as we need to know whether this is an attacking or defending deck.
+    """
+    card1 = UserCardSerializer(source='deck.card1')
+    card2 = UserCardSerializer(source='deck.card2')
+    card3 = UserCardSerializer(source='deck.card3')
+    card4 = UserCardSerializer(source='deck.card4')
+    card5 = UserCardSerializer(source='deck.card5')
+    deck_number = serializers.IntegerField()
+
+    class Meta:
+        model = Deck
+        fields = ['deck_number', 'card1', 'card2', 'card3', 'card4', 'card5']
+
+
+class UserDecksSerializer(serializers.ModelSerializer):
+    """
+    Serializes decks of a given user.
+    """
+    user_decks = DeckSerializer(many=True, source='user_decks.all')
+
+    class Meta:
+        model = UserProfile
+        fields = ['user_decks']

--- a/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/tests.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/tests.py
@@ -127,9 +127,24 @@ class DeckTestCase(TestCase):
 
 
 class UserDeckSerializerTestCase(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.creator = Creator()
+
     def test_serialization(self):
-        creator = Creator()
-        user = creator.get_user_profile_models()[0]
+        user = self.creator.get_user_profile_models()[0]
         serializer = UserDecksSerializer(user)
         data = serializer.data.get('user_decks')
-        creator.perform_deletion()
+
+        # We get a first deck from the created user
+        actual_deck1 = user.user_decks.all()[0]
+        self.assertEqual(data[0]['deck_number'], actual_deck1.deck_number)
+        # We check selected two cards
+        self.assertEqual(data[0]['card1']['id'], actual_deck1.deck.card1.card.info.id)
+        self.assertEqual(data[0]['card1']['level'], actual_deck1.deck.card1.card.level.level)
+        self.assertEqual(data[0]['card3']['id'], actual_deck1.deck.card3.card.info.id)
+        self.assertEqual(data[0]['card3']['level'], actual_deck1.deck.card3.card.level.level)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.creator.perform_deletion()

--- a/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/tests.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/tests.py
@@ -2,11 +2,13 @@ from django.db.utils import IntegrityError
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
+from battle.businesslogic.tests.Creator import Creator
 from cards.models import Card, CardInfo, CardLevel
 from . import views
 from django.contrib.auth import get_user_model
 
 from .models import UserProfile, Semester, UserCard, Deck, UserDeck
+from .serializers import UserDecksSerializer
 
 
 class UserProfileTestCase(TestCase):
@@ -122,3 +124,12 @@ class DeckTestCase(TestCase):
                                 user_profile=u1)
         failing_deck = UserDeck(deck_number=1, deck=deck, user_profile=u1)
         self.assertRaises(IntegrityError, failing_deck.save)
+
+
+class UserDeckSerializerTestCase(TestCase):
+    def test_serialization(self):
+        creator = Creator()
+        user = creator.get_user_profile_models()[0]
+        serializer = UserDecksSerializer(user)
+        data = serializer.data.get('user_decks')
+        creator.perform_deletion()

--- a/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/urls.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/urls.py
@@ -2,10 +2,12 @@ from django.conf.urls import include
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 from . import views
+from .views import UserDeckView
 
 router = DefaultRouter()
 router.register('basic', views.UserProfileViewSet)
 
 urlpatterns = [
-    path('', include(router.urls))
+    path('', include(router.urls)),
+    path('<int:pk>/decks/', UserDeckView.as_view(), name='decks'),
 ]

--- a/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/views.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/views.py
@@ -1,10 +1,10 @@
+from rest_framework.generics import RetrieveAPIView
 from rest_framework.viewsets import ModelViewSet
 
 from . import serializers
 from . import models
-
-
-# Create your views here.
+from .models import UserProfile
+from .serializers import UserDecksSerializer
 
 
 class UserProfileViewSet(ModelViewSet):
@@ -13,6 +13,51 @@ class UserProfileViewSet(ModelViewSet):
     """
     serializer_class = serializers.UserProfileSerializer
     queryset = models.UserProfile.objects.all()
+
+
+class UserDeckView(RetrieveAPIView):
+    """
+    Get decks of a given user.
+
+    Each user has two decks: Deck used to attack other players and another deck to defend themselves from other
+    attackers.
+
+    Each deck is simplified to it's number and five cards - each card having its ID and a level.
+
+    Sample JSON output:
+
+        {
+        "user_decks": [
+            {
+                "deck_number": 1,
+                "card1": {
+                    "id": 4,
+                    "level": 1
+                },
+                "card2": {
+                    "id": 2,
+                    "level": 1
+                },
+                "card3": {
+                    "id": 3,
+                    "level": 1
+                },
+                "card4": {
+                    "id": 1,
+                    "level": 1
+                },
+                "card5": {
+                    "id": 5,
+                    "level": 1
+                }
+            }
+        ]
+        }
+
+    """
+    serializer_class = UserDecksSerializer
+    queryset = UserProfile.objects.all()
+
 
 
 


### PR DESCRIPTION
Closes #292 
Na razie nie robiłem możliwości modyfikowania Decków w widoku, ale jest to coś co w przyszłości będzie trzeba zrobić żeby gracze mogli je modyfikować w aplikacji. Trzeba będzie stworzyć w każdym serializerze `create` i zaktualizować widok.

Adres URL do widoku:
`api/igusers/<pk>/decks/`

Przykład JSONa:

```json
{
"user_decks": [
    {
        "deck_number": 1,
        "card1": {
            "id": 4,
            "level": 1
        },
        "card2": {
            "id": 2,
            "level": 1
        },
        "card3": {
            "id": 3,
            "level": 1
        },
        "card4": {
            "id": 1,
            "level": 1
        },
        "card5": {
            "id": 5,
            "level": 1
        }
    }
]
}
```