### PR TITLE
Wyliczona moc efektu nie może być mniejsza niż zero

### DIFF
--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/Calculator.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/Calculator.py
@@ -23,7 +23,7 @@ class Calculator:
 
         effect_power = self._power_without_buffs(power, power_range)
         effect_power = self._calculate_buffs_influence(effect_power, buffs)
-        return effect_power
+        return max(0.0, effect_power)
 
     def _power_without_buffs(self, power, power_range):
         """

--- a/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/tests_Calculator.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/battle/businesslogic/tests/tests_Calculator.py
@@ -84,6 +84,19 @@ class CalculatorTestCase(TestCase):
             actual_value = self.instance.calculate_effect_power(self.base_power, self.power_range, self.buffs)
             self.assertGreaterEqual(actual_value, expected_min_value)
             self.assertLessEqual(actual_value, expected_max_value)
+            
+    def test_negative_fix(self):
+        import random
+        
+        # This seed returns a negative power inside the calculator.
+        random.seed(241241)
+        
+        # Calculated effect power of this ranges should never drop below zero.
+        power = 1
+        range = 10
+        val = self.instance.calculate_effect_power(power, range, [])
+        
+        self.assertEqual(0, val)
 
     @classmethod
     def tearDownClass(cls) -> None:


### PR DESCRIPTION
Poprawione.
Wyliczona moc efektu teraz jest obcinana do zera.