### PR TITLE
#362 Removed scroll on overflowing elements

### DIFF
--- a/WMIAdventure/frontend/src/js/pages/creative/CardsCreator/organisms/CardProperties/styled-components/DivScroll.js
+++ b/WMIAdventure/frontend/src/js/pages/creative/CardsCreator/organisms/CardProperties/styled-components/DivScroll.js
@@ -19,6 +19,7 @@ const DivScroll = styled.div`
   ::-webkit-scrollbar {
     display: none; /* Chrome Safari */
   }
+  margin-bottom: 10px;
   padding: 10px; 
   @media (max-width: 768px) {
     padding-top: ${({rank}) => handleExistMobile(rank)};


### PR DESCRIPTION
Closes #362
Usunąłem scrolla całkowicie. Lepiej żeby go w ogóle nie było, myślę że z perspektywy UX to wiele nie zmienia, chyba tylko stare dziadki nie korzystają z mouse scrollingu 