### PR TITLE
CORS no longer allows all hosts

### DIFF
--- a/WMIAdventure/backend/WMIAdventure_backend/WMIAdventure_backend/settings.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/WMIAdventure_backend/settings.py
@@ -62,8 +62,21 @@ MIDDLEWARE = [
 ]
 DEFAULT_FILE_STORAGE = 'db_file_storage.storage.DatabaseFileStorage'
 
-CORS_ORIGIN_ALLOW_ALL = True
-CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOW_ALL_ORIGINS = False
+CORS_ALLOWED_ORIGINS = [
+    # prod
+    'http://wmi-adventure.pl',
+    'https://wmi-adventure.pl',
+    'http://wmiadventure.projektstudencki.pl',
+    'https://wmiadventure.projektstudencki.pl',
+
+    # dev
+    'http://wmiadventure.westeurope.cloudapp.azure.com',
+    'https://wmiadventure.westeurope.cloudapp.azure.com',
+    
+    # local development
+    'http://localhost',
+]
 CORS_ALLOW_METHODS = [
     'DELETE',
     'GET',


### PR DESCRIPTION
Zezwalanie na requesty wysyłane przez wszystkie hosty (web serwery) jest unsafe i nawet fetch api krzyczy, żeby tak nie robić. Dopisałem listę hostów, które dopuszczamy do backendu.

Jeżeli chcecie odpalać u siebie tylko frontend i kierować ruch do serwera na Azure, to teraz nie będzie się dało tego robić (prawdopodobnie)