### PR TITLE
#544 Colors refactor to match Figma designs

### DIFF
--- a/WMIAdventure/frontend/src/js/components/battle/atoms/BattleResult/styled-components/Header.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/BattleResult/styled-components/Header.js
@@ -7,7 +7,7 @@ const Header = styled.h2`
   margin: 0 0 10px 0;
   text-transform: uppercase;
   text-align: center;
-  color: ${({theme}) => theme.colors.uiBlue};
+  color: ${({theme}) => theme.colors.dark};
 `;
 
 export default Header;

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/ButtonWithIcon/styled-components/IconContainer.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/ButtonWithIcon/styled-components/IconContainer.js
@@ -1,14 +1,14 @@
 import styled from 'styled-components';
 
 const IconContainer = styled.div`
-  background-color: ${({color, theme}) => color ? color : theme.colors.common};
+  background-color: ${({color, theme}) => color ? color : theme.colors.greenyBluey};
   height: 32px;
   width: 36px;
   border-radius: 6px;
   display: flex;
   justify-content: center;
   align-items: center;
-  
+
   @media (min-width: 360px) {
     height: 36px;
   }

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/ButtonWithIcon/styled-components/P.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/ButtonWithIcon/styled-components/P.js
@@ -6,7 +6,7 @@ const P = styled.p`
   font-family: 'Roboto', sans-serif;
   text-transform: uppercase;
   font-size: 14px;
-  color: ${({theme}) => theme.colors.uiBlue};
+  color: ${({theme}) => theme.colors.dark};
   font-weight: ${({theme}) => theme.weight.medium};
 `;
 

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/KuceVs/styled-components/Vs.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/KuceVs/styled-components/Vs.js
@@ -4,7 +4,7 @@ const Vs = styled.p`
   font-size: 26px;
   font-family: 'Open Sans', sans-serif;
   font-weight: ${({theme}) => theme.weight.bold};
-  color: ${({theme}) => theme.colors.uiBlue};
+  color: ${({theme}) => theme.colors.dark};
 `;
 
 export default Vs;

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/Pager/styled-components/PageButton.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/Pager/styled-components/PageButton.js
@@ -5,20 +5,20 @@ const PageButton = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
-  
+
   /* Sizing */
   width: 32px;
   height: 32px;
-  
+
   /* Styling */
-  background: ${({theme, disabled}) => !disabled ? theme.colors.ui02 : theme.colors.ui05};
+  background: ${({theme, disabled}) => !disabled ? theme.colors.whiteAlmost : theme.colors.lightGray};
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
   border-radius: 50%;
   border-style: none;
-  cursor: ${({disabled}) => disabled ? 'auto' : 'pointer'} ;
+  cursor: ${({disabled}) => disabled ? 'auto' : 'pointer'};
 
   /* Font */
-  color: ${({theme, disabled}) => !disabled ? theme.colors.text01 : theme.colors.grey1};
+  color: ${({theme, disabled}) => !disabled ? theme.colors.dark : theme.colors.light2};
   font-family: 'Open Sans', sans-serif;
   font-style: normal;
   font-weight: 600;

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/TinyCards/styled-components/ImageContainer.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/TinyCards/styled-components/ImageContainer.js
@@ -7,7 +7,7 @@ const ImageContainer = styled.div`
   justify-content: center;
   align-items: center;
   border-radius: 12px;
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
   margin: 0;
 `;

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/UserInfo/styled-components/Label.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/UserInfo/styled-components/Label.js
@@ -6,7 +6,7 @@ const Label = styled.p`
   font-size: 12px;
   font-family: 'Roboto', sans-serif;
   font-weight: ${({theme}) => theme.weight.light};
-  color: ${({theme}) => theme.colors.lightGray2};
+  color: ${({theme}) => theme.colors.darkGray};
 `;
 
 export default Label;

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/UserInfo/styled-components/Value.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/UserInfo/styled-components/Value.js
@@ -6,7 +6,7 @@ const Value = styled.p`
   font-size: 18px;
   font-family: 'Roboto', sans-serif;
   font-weight: ${({theme}) => theme.weight.regular};
-  color: ${({theme}) => theme.colors.uiBlue};
+  color: ${({theme}) => theme.colors.dark};
 `;
 
 export default Value;

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/UserLabel/styled-components/Label.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/UserLabel/styled-components/Label.js
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
 function backColorHandler(theme, term, level, rank) {
-    if(level < 10 || rank < 20 || term < 4)
-        return theme.colors.common;
-    else if((level >= 10 && level < 20) || (rank >= 20 && rank < 50) || (term >= 4 && term < 6))
-        return theme.colors.gold;
-    else if(level >= 20 || rank >= 50 || term >= 6)
-        return theme.colors.epic;
+    if (level < 10 || rank < 20 || term < 4)
+        return theme.colors.greenyBluey;
+    else if ((level >= 10 && level < 20) || (rank >= 20 && rank < 50) || (term >= 4 && term < 6))
+        return theme.colors.yellowyOrangy;
+    else if (level >= 20 || rank >= 50 || term >= 6)
+        return theme.colors.purplyPinky;
 }
 
 const Label = styled.div`

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/UserLabel/styled-components/Number.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/UserLabel/styled-components/Number.js
@@ -4,7 +4,7 @@ const Number = styled.p`
   font-size: 14px;
   font-family: 'Roboto', sans-serif;
   font-weight: ${({theme}) => theme.weight.medium};
-  color: ${({theme}) => theme.colors.darkgrey};
+  color: ${({theme}) => theme.colors.dark};
   margin: 2px 0 0 0;
   padding-left: 10px;
 `;

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/UserLevel/styled-components/LevelNumber.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/UserLevel/styled-components/LevelNumber.js
@@ -8,8 +8,8 @@ const LevelNumber = styled.div`
   height: 28px;
   border-bottom-left-radius: 76px;
   border-top-left-radius: 76px;
-  color: ${({theme}) => theme.colors.ui01};
-  background-color: ${({theme}) => theme.colors.darkgrey};
+  color: ${({theme}) => theme.colors.whiteAlmost};
+  background-color: ${({theme}) => theme.colors.dark};
   font-family: 'Roboto', sans-serif;
   font-size: 18px;
   font-weight: ${({theme}) => theme.weight.regular};

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/UserLevel/styled-components/ValueDiv.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/UserLevel/styled-components/ValueDiv.js
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
 function handleColor(number, theme) {
-    if(number < 10)
-        return theme.colors.common;
-    else if((number >= 10 && number < 20))
-        return theme.colors.gold;
-    else if(number >= 20)
-        return theme.colors.epic;
+    if (number < 10)
+        return theme.colors.greenyBluey;
+    else if ((number >= 10 && number < 20))
+        return theme.colors.yellowyOrangy;
+    else if (number >= 20)
+        return theme.colors.purplyPinky;
 }
 
 const ValueDiv = styled.div`

--- a/WMIAdventure/frontend/src/js/components/battle/molecules/Deck/styled-components/Header.js
+++ b/WMIAdventure/frontend/src/js/components/battle/molecules/Deck/styled-components/Header.js
@@ -5,7 +5,7 @@ const Header = styled.p`
   font-size: 24px;
   margin: 0 0 26px 0;
   font-weight: ${({theme}) => theme.weight.semibold};
-  color: ${({theme}) => theme.colors.uiBlue};
+  color: ${({theme}) => theme.colors.dark};
   text-transform: uppercase;
 `;
 

--- a/WMIAdventure/frontend/src/js/components/battle/molecules/TinyUserProfile/styled-components/H2.js
+++ b/WMIAdventure/frontend/src/js/components/battle/molecules/TinyUserProfile/styled-components/H2.js
@@ -5,9 +5,9 @@ const H2 = styled.h2`
   font-size: 18px;
   font-family: 'Open Sans', sans-serif;
   font-weight: ${({theme}) => theme.weight.semibold};
-  color: ${({theme}) => theme.colors.uiBlue};
+  color: ${({theme}) => theme.colors.dark};
 
-  @media(min-width: ${({theme}) => theme.overMobile}px) {
+  @media (min-width: ${({theme}) => theme.overMobile}px) {
     font-size: 24px;
     margin: ${({vertical}) => vertical ? '0 0 10px 0' : '0 0 14px 0'};
   }

--- a/WMIAdventure/frontend/src/js/components/battle/molecules/TinyUserProfile/styled-components/ImageContainer.js
+++ b/WMIAdventure/frontend/src/js/components/battle/molecules/TinyUserProfile/styled-components/ImageContainer.js
@@ -4,21 +4,21 @@ const ImageContainer = styled.div`
   order: -1;
   width: 48px;
   height: 48px;
-  background-color: ${({theme}) => theme.colors.uiGreen};
+  background-color: ${({theme}) => theme.colors.greenyBluey};
   border-radius: 50%;
   margin-right: 10px;
 
-  @media(min-width: ${({theme}) => theme.overMobile}px) {
+  @media (min-width: ${({theme}) => theme.overMobile}px) {
     width: ${({vertical}) => vertical ? '84px' : '72px'};
     height: ${({vertical}) => vertical ? '84px' : '72px'};
-    background-color: ${({theme, vertical}) => vertical ? theme.colors.uiGreen : theme.colors.red};
+    background-color: ${({theme, vertical}) => vertical ? theme.colors.greenyBluey : theme.colors.red};
     margin: ${({vertical}) => vertical ? '0 0 10px 0' : '0 10px 0 0'};
   }
-  
-  @media(min-width: 1172px) {
+
+  @media (min-width: 1172px) {
     width: ${({vertical}) => vertical ? '84px' : '106px'};
     height: ${({vertical}) => vertical ? '84px' : '106px'};
-    background-color: ${({theme, vertical}) => vertical ? theme.colors.uiGreen : theme.colors.red};
+    background-color: ${({theme, vertical}) => vertical ? theme.colors.greenyBluey : theme.colors.red};
     margin: ${({vertical}) => vertical ? '0 0 10px 0' : '0 24px 0 0'};
   }
 `;

--- a/WMIAdventure/frontend/src/js/components/battle/molecules/UserListItem/styled-components/AvatarContainer.js
+++ b/WMIAdventure/frontend/src/js/components/battle/molecules/UserListItem/styled-components/AvatarContainer.js
@@ -4,11 +4,11 @@ import kLetter from '../../../../../../assets/icons/k-letter.svg';
 const AvatarContainer = styled.div`
   width: 36px;
   height: 36px;
-  background-color: ${({theme, access}) => access ? theme.colors.uiGreen : theme.colors.grey2};
+  background-color: ${({theme, access}) => access ? theme.colors.greenyBluey : theme.colors.lightGray};
   border-radius: 50%;
   position: relative;
   margin-right: 10px;
-  
+
   &:after {
     display: ${({access}) => access ? 'block' : 'none'};
     content: '';
@@ -22,8 +22,8 @@ const AvatarContainer = styled.div`
     background-position: center;
     background-image: url(${kLetter});
   }
-  
-  @media(min-width: ${({theme}) => theme.overMobile}px) {
+
+  @media (min-width: ${({theme}) => theme.overMobile}px) {
     width: 44px;
     height: 44px;
 

--- a/WMIAdventure/frontend/src/js/components/battle/molecules/UserListItem/styled-components/Item.js
+++ b/WMIAdventure/frontend/src/js/components/battle/molecules/UserListItem/styled-components/Item.js
@@ -10,18 +10,18 @@ function visibilityHandler(displayedUsername, searchInput) {
 const Item = styled.li`
   display: ${({displayedUsername, searchInput}) => visibilityHandler(displayedUsername, searchInput)};
   align-items: center;
-  
+
   padding: 6px 10px;
   width: 100%;
   height: 60px;
   transition: background-color 0.3s ease-in-out;
   border-radius: 6px;
   margin: 10px 0;
-  
+
   &:hover {
-    background-color: ${({theme}) => theme.colors.userItemHover};
+    background-color: ${({theme}) => theme.colors.lightGray};
   }
-  
+
   @media (min-width: ${({theme}) => theme.overMobile}px) {
     height: 72px;
   }

--- a/WMIAdventure/frontend/src/js/components/battle/molecules/UserListItem/styled-components/Login.js
+++ b/WMIAdventure/frontend/src/js/components/battle/molecules/UserListItem/styled-components/Login.js
@@ -4,7 +4,7 @@ const Login = styled.div`
   font-family: 'Roboto', sans-serif;
   font-weight: ${({theme}) => theme.weight.medium};
   font-size: 18px;
-  color: ${({theme, access}) => access ? theme.colors.darkgrey : theme.colors.grey2};
+  color: ${({theme, access}) => access ? theme.colors.dark : theme.colors.lightGray};
   margin-bottom: 10px;
 `;
 

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/OpponentSelected/OpponentSelected.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/OpponentSelected/OpponentSelected.js
@@ -36,7 +36,7 @@ class OpponentSelected extends React.Component {
             .then(user => this.setState({caller: user}))
         getCurrentUserDecks()
             .then(resp => {
-                if(resp){
+                if (resp) {
                     const attackerDeck = resp[0];
                     this.setState({userDeck: attackerDeck});
                 }
@@ -48,7 +48,7 @@ class OpponentSelected extends React.Component {
         this.props.kuceStartFight();
         fightWithUser(this.props.opponent.id)
             .then(response => {
-                if(response.ok) {
+                if (response.ok) {
                     response.json()
                         .then(data => {
                             this.postBattle(data);
@@ -98,7 +98,7 @@ class OpponentSelected extends React.Component {
     }
 
     handleHiding = () => {
-        if(!this.state.popUpHover)
+        if (!this.state.popUpHover)
             this.props.closeUserPreviewHandler();
     }
 
@@ -113,35 +113,38 @@ class OpponentSelected extends React.Component {
                             <GridContainer>
                                 <FlexCenterContainer>
                                     <FlexGapContainer gap={'40px'} setMargin={'32px 0 0 0'}>
-                                        <UserInfo label={'Wygrane'} value={'24'} setMargin={'0'} />
-                                        <UserInfo label={'Przegrane'} value={'24'} setMargin={'0'} />
-                                        <UserInfo label={'Ratio'} value={'50%'} setMargin={'0'} />
+                                        <UserInfo label={'Wygrane'} value={'24'} setMargin={'0'}/>
+                                        <UserInfo label={'Przegrane'} value={'24'} setMargin={'0'}/>
+                                        <UserInfo label={'Ratio'} value={'50%'} setMargin={'0'}/>
                                     </FlexGapContainer>
                                     <TinyUserProfile displayedUsername={this.state.caller} setMargin={'24px 0 0 0'}
                                                      term={7} level={50} rank={2} avatar={null}/>
-                                    <KuceVs />
-                                    <TinyUserProfile displayedUsername={this.props.opponent.username} setMargin={'0 0 24px 0'}
+                                    <KuceVs/>
+                                    <TinyUserProfile displayedUsername={this.props.opponent.username}
+                                                     setMargin={'0 0 24px 0'}
                                                      term={7} level={39} rank={15} avatar={null}/>
                                     <FlexGapContainer gap={'40px'}>
-                                        <UserInfo label={'Wygrane'} value={'24'} setMargin={'0'} />
-                                        <UserInfo label={'Przegrane'} value={'24'} setMargin={'0'} />
-                                        <UserInfo label={'Ratio'} value={'50%'} setMargin={'0'} />
+                                        <UserInfo label={'Wygrane'} value={'24'} setMargin={'0'}/>
+                                        <UserInfo label={'Przegrane'} value={'24'} setMargin={'0'}/>
+                                        <UserInfo label={'Ratio'} value={'50%'} setMargin={'0'}/>
                                     </FlexGapContainer>
                                 </FlexCenterContainer>
 
                                 <FlexEndContainer>
-                                    <TinyCards deck={this.state.userDeck} setMargin={'24px 0 36px 0'} />
+                                    <TinyCards deck={this.state.userDeck} setMargin={'24px 0 36px 0'}/>
                                     <FlexGapContainer gap={'36px'}>
-                                        <ButtonWithIcon setMargin={'0 36px 0 0'} handler={this.props.closeUserPreviewHandler}
-                                                        color={theme.colors.gold} icon={xClose}>
+                                        <ButtonWithIcon setMargin={'0 36px 0 0'}
+                                                        handler={this.props.closeUserPreviewHandler}
+                                                        color={theme.colors.yellowyOrangy} icon={xClose}>
                                             Wróć
                                         </ButtonWithIcon>
-                                        <ButtonWithIcon setMargin={'0'} color={theme.colors.epic} icon={battleIcon}>
+                                        <ButtonWithIcon setMargin={'0'} color={theme.colors.purplyPinky}
+                                                        icon={battleIcon}>
                                             Walcz
                                         </ButtonWithIcon>
                                     </FlexGapContainer>
                                     <ButtonWithIcon handler={this.quickBattleRunHandler} setMargin={'14px 0 16px 0'}
-                                                    color={theme.colors.common} icon={fastIcon}>
+                                                    color={theme.colors.greenyBluey} icon={fastIcon}>
                                         Szybka walka
                                     </ButtonWithIcon>
                                 </FlexEndContainer>
@@ -151,7 +154,7 @@ class OpponentSelected extends React.Component {
                                     closeHandler={this.quickBattleCloseHandler}
                                     attacker={this.state.caller}
                                     opponent={this.props.opponent.username}
-                                    setTranslateY={this.state.postBattlePos} />
+                                    setTranslateY={this.state.postBattlePos}/>
                     </>
                 </Media>
 
@@ -165,39 +168,40 @@ class OpponentSelected extends React.Component {
                                    setTranslateY={this.props.setTranslateY}
                                    hoverTrue={this.hoverTrue} hoverFalse={this.hoverFalse}>
                                 <FlexGapContainer gap={'10px'} setWidth={'100%'}>
-                                    <ColumnGapContainer gap={'24px'}  setMargin={'0 0 0 26px'}>
+                                    <ColumnGapContainer gap={'24px'} setMargin={'0 0 0 26px'}>
                                         <TinyUserProfile displayedUsername={this.state.caller} setMargin={'0'}
                                                          term={7} level={39} rank={15} avatar={null} vertical/>
                                         <FlexGapContainer gap={'52px'}>
-                                            <UserInfo label={'Wygrane'} value={'24'} setMargin={'0'} />
-                                            <UserInfo label={'Przegrane'} value={'24'} setMargin={'0'} />
-                                            <UserInfo label={'Ratio'} value={'50%'} setMargin={'0'} />
+                                            <UserInfo label={'Wygrane'} value={'24'} setMargin={'0'}/>
+                                            <UserInfo label={'Przegrane'} value={'24'} setMargin={'0'}/>
+                                            <UserInfo label={'Ratio'} value={'50%'} setMargin={'0'}/>
                                         </FlexGapContainer>
-                                        <TinyCards deck={this.state.userDeck} setMargin={'0'} gap={'10px'} />
+                                        <TinyCards deck={this.state.userDeck} setMargin={'0'} gap={'10px'}/>
                                     </ColumnGapContainer>
-                                    <KuceVs />
+                                    <KuceVs/>
                                     <ColumnGapContainer gap={'24px'} setMargin={'0 26px 0 0'}>
-                                        <TinyUserProfile displayedUsername={this.props.opponent.username} setMargin={'0'}
+                                        <TinyUserProfile displayedUsername={this.props.opponent.username}
+                                                         setMargin={'0'}
                                                          term={7} level={39} rank={15} avatar={null} vertical/>
                                         <FlexGapContainer gap={'52px'}>
-                                            <UserInfo label={'Wygrane'} value={'24'} setMargin={'0'} />
-                                            <UserInfo label={'Przegrane'} value={'24'} setMargin={'0'} />
-                                            <UserInfo label={'Ratio'} value={'50%'} setMargin={'0'} />
+                                            <UserInfo label={'Wygrane'} value={'24'} setMargin={'0'}/>
+                                            <UserInfo label={'Przegrane'} value={'24'} setMargin={'0'}/>
+                                            <UserInfo label={'Ratio'} value={'50%'} setMargin={'0'}/>
                                         </FlexGapContainer>
-                                        <TinyCards deck={null} setMargin={'0'} gap={'10px'} />
+                                        <TinyCards deck={null} setMargin={'0'} gap={'10px'}/>
                                     </ColumnGapContainer>
                                 </FlexGapContainer>
 
                                 <FlexGapContainer gap={'40px'} setMargin={'36px 0 0 0'}>
                                     <ButtonWithIcon setMargin={'0'} handler={this.props.closeUserPreviewHandler}
-                                                    color={theme.colors.gold} icon={xClose}>
+                                                    color={theme.colors.yellowyOrangy} icon={xClose}>
                                         Wróć
                                     </ButtonWithIcon>
-                                    <ButtonWithIcon setMargin={'0'} color={theme.colors.epic} icon={battleIcon}>
+                                    <ButtonWithIcon setMargin={'0'} color={theme.colors.purplyPinky} icon={battleIcon}>
                                         Walcz
                                     </ButtonWithIcon>
                                     <ButtonWithIcon handler={this.quickBattleRunHandler} setMargin={'0'}
-                                                    color={theme.colors.common} icon={fastIcon}>
+                                                    color={theme.colors.greenyBluey} icon={fastIcon}>
                                         Szybka walka
                                     </ButtonWithIcon>
                                 </FlexGapContainer>
@@ -208,7 +212,7 @@ class OpponentSelected extends React.Component {
                                     attacker={this.state.caller}
                                     opponent={this.props.opponent.username}
                                     setOpacity={this.state.postBattleOpacity}
-                                    setTranslateY={this.state.postBattlePos} />
+                                    setTranslateY={this.state.postBattlePos}/>
                     </>
                 </Media>
             </>

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/PostBattle/styled-components/Decoration.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/PostBattle/styled-components/Decoration.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 const Decoration = styled.div`
-  background-color: ${({theme, win}) => win ? theme.colors.common : theme.colors.red};
+  background-color: ${({theme, win}) => win ? theme.colors.greenyBluey : theme.colors.red};
   width: 100%;
   height: 5px;
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/PostBattle/styled-components/Div.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/PostBattle/styled-components/Div.js
@@ -9,7 +9,7 @@ const Div = styled.div`
   position: relative;
   margin-bottom: 10px;
   padding-top: 24px;
-  
+
   &:before {
     content: "";
     position: absolute;
@@ -21,7 +21,7 @@ const Div = styled.div`
     height: 50px;
     border-bottom-left-radius: 20px;
     border-bottom-right-radius: 20px;
-    background-color: ${({theme, win}) => win ? theme.colors.common : theme.colors.red};
+    background-color: ${({theme, win}) => win ? theme.colors.greenyBluey : theme.colors.red};
     box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
   }
 
@@ -36,7 +36,7 @@ const Div = styled.div`
     height: 50px;
     border-bottom-left-radius: 20px;
     border-bottom-right-radius: 20px;
-    background-color: ${({theme, win}) => win ? theme.colors.common : theme.colors.red};
+    background-color: ${({theme, win}) => win ? theme.colors.greenyBluey : theme.colors.red};
     box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
   }
 

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/SwipeProfile/styled-components/Edit.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/SwipeProfile/styled-components/Edit.js
@@ -9,7 +9,7 @@ const Edit = styled.button`
   padding: 0;
   margin: 0;
   background-color: ${({theme}) => theme.colors.light2};
-  color: ${({theme}) => theme.colors.uiBlue};
+  color: ${({theme}) => theme.colors.dark};
   font-weight: ${({theme}) => theme.weight.light};
   font-size: 14px;
   font-family: 'Open Sans', sans-serif;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/AfterSendCard/styled-components/Button.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/AfterSendCard/styled-components/Button.js
@@ -2,27 +2,27 @@ import styled from 'styled-components';
 
 const Button = styled.button`
   display: flex;
-  
+
   /* Flex options */
   justify-content: center;
   align-items: center;
-  
+
   /* Other */
   padding: 16px 40px;
-  @media (max-width: ${({theme}) => theme.overMobile}px){
+  @media (max-width: ${({theme}) => theme.overMobile}px) {
     padding: 8px 24px;
   }
   text-align: center;
-  
+
   /* Styling */
-  border: 2px solid ${({theme}) => theme.colors.text01};
+  border: 2px solid ${({theme}) => theme.colors.dark};
   border-radius: 12px;
   cursor: pointer;
-  
+
   /* Font styling */
   font-size: 18px;
-  font-weight: ${({theme}) =>  theme.weight.bold};
-  color: ${({theme}) => theme.colors.text01};
+  font-weight: ${({theme}) => theme.weight.bold};
+  color: ${({theme}) => theme.colors.dark};
 `;
 
 export default Button;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/AfterSendCard/styled-components/Header.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/AfterSendCard/styled-components/Header.js
@@ -3,14 +3,14 @@ import styled from 'styled-components'
 const Header = styled.h1`
   /* Styling */
   font-size: 36px;
-  @media (max-width: ${({theme}) => theme.overMobile}px){
+  @media (max-width: ${({theme}) => theme.overMobile}px) {
     font-size: 24px;
   };
   font-weight: ${({theme}) => theme.weight.semibold};
   line-height: 60%;
   color: ${
-    ({theme}) => theme.colors.text01
-};
+          ({theme}) => theme.colors.dark
+  };
 `;
 
 export default Header;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/AfterSendCard/styled-components/InfoText.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/AfterSendCard/styled-components/InfoText.js
@@ -3,18 +3,18 @@ import styled from 'styled-components'
 const InfoText = styled.div`
   /* Size */
   max-width: 372px;
-  
+
   /* Styling */
   text-align: center;
   font-size: 24px;
-  @media (max-width: ${({theme}) => theme.overMobile}px){
+  @media (max-width: ${({theme}) => theme.overMobile}px) {
     font-size: 18px;
   }
-  
+
   font-weight: ${({theme}) => theme.weight.light};
   line-height: 121%;
   color: ${
-          ({theme}) => theme.colors.text02
+          ({theme}) => theme.colors.dark
   };
 `;
 

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/BeforeSendCard/styled-components/Button.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/BeforeSendCard/styled-components/Button.js
@@ -2,27 +2,27 @@ import styled from 'styled-components';
 
 const Button = styled.button`
   display: flex;
-  
+
   /* Flex options */
   justify-content: center;
   align-items: center;
-  
+
   /* Other */
   padding: 16px 40px;
-  @media (max-width: ${({theme}) => theme.overMobile}px){
+  @media (max-width: ${({theme}) => theme.overMobile}px) {
     padding: 8px 24px;
   }
   text-align: center;
-  
+
   /* Styling */
-  border: 2px solid ${({theme}) => theme.colors.text01};
+  border: 2px solid ${({theme}) => theme.colors.dark};
   border-radius: 12px;
   cursor: pointer;
-  
+
   /* Font styling */
   font-size: 18px;
-  font-weight: ${({theme}) =>  theme.weight.bold};
-  color: ${({theme}) => theme.colors.text01};
+  font-weight: ${({theme}) => theme.weight.bold};
+  color: ${({theme}) => theme.colors.dark};
 `;
 
 export default Button;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/BeforeSendCard/styled-components/Header.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/BeforeSendCard/styled-components/Header.js
@@ -3,14 +3,14 @@ import styled from 'styled-components'
 const Header = styled.h1`
   /* Styling */
   font-size: 36px;
-  @media (max-width: ${({theme}) => theme.overMobile}px){
+  @media (max-width: ${({theme}) => theme.overMobile}px) {
     font-size: 24px;
   };
   font-weight: ${({theme}) => theme.weight.semibold};
   line-height: 60%;
   color: ${
-    ({theme}) => theme.colors.text01
-};
+          ({theme}) => theme.colors.dark
+  };
 `;
 
 export default Header;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/BeforeSendCard/styled-components/InfoText.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/BeforeSendCard/styled-components/InfoText.js
@@ -3,18 +3,18 @@ import styled from 'styled-components'
 const InfoText = styled.div`
   /* Size */
   max-width: 372px;
-  
+
   /* Styling */
   text-align: center;
   font-size: 24px;
-  @media (max-width: ${({theme}) => theme.overMobile}px){
+  @media (max-width: ${({theme}) => theme.overMobile}px) {
     font-size: 18px;
   }
-  
+
   font-weight: ${({theme}) => theme.weight.light};
   line-height: 121%;
   color: ${
-          ({theme}) => theme.colors.text02
+          ({theme}) => theme.colors.dark
   };
 `;
 

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/BeforeSendCard/styled-components/TextArea.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/BeforeSendCard/styled-components/TextArea.js
@@ -3,21 +3,21 @@ import styled from 'styled-components';
 const TextArea = styled.textarea`
   /* Flex options */
   align-self: stretch;
-  
+
   /* textarea options */
   resize: none;
   padding: 12px;
-  
+
   /* Styling */
   border-radius: 4px;
   border: none;
-  background-color: ${({theme}) => theme.colors.grey1};
-  
+  background-color: ${({theme}) => theme.colors.light2};
+
   font-size: 18px;
   font-weight: ${({theme}) => theme.weight.light};
-  
+
   :focus {
-    outline: dotted 1px ${({theme}) => theme.colors.grey3};
+    outline: dotted 1px ${({theme}) => theme.colors.darkGray};
   }
 `;
 

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/Card/styled-components/Button.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/Card/styled-components/Button.js
@@ -22,7 +22,7 @@ const Button = styled.button`
   position: relative;
 
   :hover {
-    background-color: ${({theme}) => theme.colors.grey2};
+    background-color: ${({theme}) => theme.colors.lightGray};
   }
   
   :before {

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/Card/styled-components/Name.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/Card/styled-components/Name.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 const Name = styled.p`
-  color: ${({theme}) => theme.colors.borderLine};
+  color: ${({theme}) => theme.colors.dark};
   font-size: 18px;
   font-weight: 700;
   padding: 0;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/Card/styled-components/Subject.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/Card/styled-components/Subject.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 const Subject = styled.p`
   font-size: 12px;
   font-weight: 200;
-  color: ${({theme}) => theme.colors.borderLine};
+  color: ${({theme}) => theme.colors.dark};
   padding: 0;
   margin: 0;
   max-width: 260px;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/CardDescribeInputs/styled-components/CardImagePreview.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/CardDescribeInputs/styled-components/CardImagePreview.js
@@ -4,17 +4,17 @@ const CardImagePreview = styled.img`
   /* Size */
   width: 200px;
   height: 200px;
-  @media (max-width: ${({theme}) => theme.overMobile}px){
+  @media (max-width: ${({theme}) => theme.overMobile}px) {
     width: 138px;
     height: 138px;
   }
-  
-  
+
+
   /* Styling */
   border-radius: 4px;
-  background-color: ${({theme}) => theme.colors.grey1};
+  background-color: ${({theme}) => theme.colors.light2};
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
-  
+
   object-fit: contain;
 `;
 

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/CardDescribeInputs/styled-components/DivInput.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/CardDescribeInputs/styled-components/DivInput.js
@@ -6,7 +6,7 @@ const DivInput = styled.div`
   justify-content: center;
   align-items: center;
   border-radius: 4px;
-  background-color: ${({theme}) => theme.colors.grey1};
+  background-color: ${({theme}) => theme.colors.light2};
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
   width: 100%;
   height: 40px;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/CardDescribeInputs/styled-components/Fieldset.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/CardDescribeInputs/styled-components/Fieldset.js
@@ -23,7 +23,7 @@ const Fieldset = styled.fieldset`
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.15);
   
   animation: ${Animation} .6s ease-in-out;
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
 `;
 
 export default Fieldset;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/CardDescribeInputs/styled-components/ImageInputPrompt.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/CardDescribeInputs/styled-components/ImageInputPrompt.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 const ImageInputPrompt = styled.p`
   font-size: 20px;
   font-weight: ${({theme}) => theme.weight.semibold};
-  color: ${({theme}) => theme.colors.new_text01};
+  color: ${({theme}) => theme.colors.dark};
 `;
 
 export default ImageInputPrompt;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/CardDescribeInputs/styled-components/Input.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/CardDescribeInputs/styled-components/Input.js
@@ -3,11 +3,11 @@ import styled from 'styled-components';
 const Input = styled.input`
   border: none;
   border-bottom: solid 2px #333333;
-  background-color: ${({theme}) => theme.colors.grey1};
+  background-color: ${({theme}) => theme.colors.light2};
   width: 80%;
   height: 20px;
   font-size: 12px;
-  
+
   :focus {
     outline: dotted 1px #333333;
   }

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/CardDescribePreview/styled-components/H1.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/CardDescribePreview/styled-components/H1.js
@@ -1,16 +1,17 @@
 import styled from 'styled-components';
 
 function handleFontSize(len) {
-    if(len > 16) {
+    if (len > 16) {
         return '20px';
-    } return '28px';
+    }
+    return '28px';
 }
 
 const H1 = styled.h1`
   font-size: ${({len}) => handleFontSize(len)};
   font-weight: 600;
   margin: 0 0 16px 0;
-  color: ${({theme}) => theme.colors.ui01};
+  color: ${({theme}) => theme.colors.whiteAlmost};
   overflow-wrap: anywhere;
   max-width: 400px;
   

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/CardDescribePreview/styled-components/P.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/CardDescribePreview/styled-components/P.js
@@ -1,19 +1,19 @@
 import styled from 'styled-components';
 
 function handleFontSize(tooltip, len) {
-    if(tooltip) {
-        if(len > 40)
+    if (tooltip) {
+        if (len > 40)
             return '12px';
         return '14px';
     } else {
-        if(len > 30)
+        if (len > 30)
             return '16px';
         return '18px';
     }
 }
 
 const P = styled.p`
-  color: ${({theme}) => theme.colors.ui01};
+  color: ${({theme}) => theme.colors.whiteAlmost};
   margin: ${({tooltip}) => tooltip ? '0' : '0 0 16px 0'};
   font-size: ${({tooltip, len}) => handleFontSize(tooltip, len)};
   max-width: 290px;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/CostInputs/styled-components/Div.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/CostInputs/styled-components/Div.js
@@ -8,7 +8,7 @@ const Div = styled.div`
   width: 100%;
   height: 48px;
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   margin-bottom: 16px;
 `;
 

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/CostInputs/styled-components/Input.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/CostInputs/styled-components/Input.js
@@ -4,8 +4,8 @@ const Input = styled.input`
   width: 48px;
   height: 24px;
   border: none;
-  color: ${({theme}) => theme.colors.borderLine};
-  border-bottom: 1px solid ${({theme}) => theme.colors.grey2};
+  color: ${({theme}) => theme.colors.dark};
+  border-bottom: 1px solid ${({theme}) => theme.colors.lightGray};
   text-align: end;
   padding-right: 6px;
   font-size: 16px;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/CostInputs/styled-components/Label.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/CostInputs/styled-components/Label.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 const Label = styled.label`
   font-size: 16px;
   font-weight: 700;
-  color: ${({theme}) => theme.colors.borderLine};
+  color: ${({theme}) => theme.colors.dark};
 `;
 
 export default Label;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/CreatorOption/styled-components/Button.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/CreatorOption/styled-components/Button.js
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
 const Button = styled.button`
-  color: ${({theme}) => theme.colors.ui01};
+  color: ${({theme}) => theme.colors.whiteAlmost};
   font-size: 18px;
   filter: drop-shadow(0 4px 4px rgba(0, 0, 0, 0.25));
   width: 100%;
   background-color: transparent;
-  border: 2px solid ${({theme}) => theme.colors.ui01};
+  border: 2px solid ${({theme}) => theme.colors.whiteAlmost};
   border-radius: 10px;
   display: flex;
   justify-content: center;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/Effect/styled-components/Button.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/Effect/styled-components/Button.js
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 
 function visibilityHandler(name, searchInput) {
-  if (name.toLowerCase().includes(searchInput.toLowerCase()) || searchInput === '') {
-    return 'flex';
-  }
-  return 'none';
+    if (name.toLowerCase().includes(searchInput.toLowerCase()) || searchInput === '') {
+        return 'flex';
+    }
+    return 'none';
 }
 
 const Button = styled.button`
@@ -15,17 +15,17 @@ const Button = styled.button`
   flex-direction: column;
   justify-content: center;
   background-color: ${
-          ({theme, disabled}) => disabled ? theme.colors.grey2 : "transparent"
-  };
+    ({theme, disabled}) => disabled ? theme.colors.lightGray : "transparent"
+};
   border: none;
   transition: background-color 0.4s ease-in-out;
   cursor: ${
-      ({disabled}) => disabled ? "initial" : "pointer"
-  };
+    ({disabled}) => disabled ? "initial" : "pointer"
+};
   
   :hover {
     // Ternary expression in case disabled button color changes in the future.
-    background-color: ${({disabled, theme}) => disabled ? theme.colors.grey2 : theme.colors.grey2};
+    background-color: ${({disabled, theme}) => disabled ? theme.colors.lightGray : theme.colors.lightGray};
   }
 `;
 

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/Effect/styled-components/Name.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/Effect/styled-components/Name.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 const Name = styled.p`
   color: ${
-    ({ disabled, theme}) => disabled ? theme.colors.ui07trans : theme.colors.ui07
+      ({disabled, theme}) => disabled ? theme.colors.darkTrans : theme.colors.dark
   };
   font-size: 18px;
   font-weight: 700;
@@ -10,7 +10,7 @@ const Name = styled.p`
   margin: 0 0 6px 0;
   max-width: 280px;
   text-align: start;
-  color: ${({theme}) => theme.colors.borderLine};
+  color: ${({theme}) => theme.colors.dark};
 `;
 
 export default Name;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/Effect/styled-components/Tooltip.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/Effect/styled-components/Tooltip.js
@@ -3,13 +3,13 @@ import styled from 'styled-components';
 const Tooltip = styled.p`
   font-size: 12px;
   font-weight: 200;
-  color: ${({theme}) => theme.colors.grey3};
+  color: ${({theme}) => theme.colors.darkGray};
   padding: 0;
   margin: 0;
   max-width: 260px;
   line-height: 16px;
   text-align: start;
-  color: ${({theme}) => theme.colors.borderLine};
+  color: ${({theme}) => theme.colors.dark};
 `;
 
 export default Tooltip;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/EffectInput/styled-components/Fieldset.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/EffectInput/styled-components/Fieldset.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 const Fieldset = styled.fieldset`
   border: none;
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
   border-radius: 10px;
   padding: 10px;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/EffectInput/styled-components/Header.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/EffectInput/styled-components/Header.js
@@ -5,7 +5,7 @@ const Header = styled.p`
   font-weight: 700;
   margin: 0 0 16px 0;
   max-width: 90%;
-  color: ${({theme}) => theme.colors.borderLine};
+  color: ${({theme}) => theme.colors.dark};
 `;
 
 export default Header;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/EffectInput/styled-components/InputNumber.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/EffectInput/styled-components/InputNumber.js
@@ -7,8 +7,8 @@ const InputNumber = styled.input`
   text-align: center;
   width: 28px;
   height: 26px;
-  color: ${({theme}) => theme.colors.borderLine};
-  border-bottom: 1px solid ${({theme}) => theme.colors.borderLine};
+  color: ${({theme}) => theme.colors.dark};
+  border-bottom: 1px solid ${({theme}) => theme.colors.dark};
   -moz-appearance: textfield;
 
   ::-webkit-inner-spin-button {
@@ -16,7 +16,6 @@ const InputNumber = styled.input`
     margin: 0;
   }
 `;
-
 
 
 export default InputNumber;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/EffectInput/styled-components/Label.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/EffectInput/styled-components/Label.js
@@ -3,11 +3,11 @@ import styled from 'styled-components';
 const Label = styled.label`
   font-size: 18px;
   font-weight: 200;
-  color: ${({theme}) => theme.colors.borderLine};
+  color: ${({theme}) => theme.colors.dark};
   margin-right: ${({marginRight}) => marginRight ? '20px' : 0};
   border-radius: 8px;
   padding: 2px 4px;
-  border: ${({checked, theme}) => checked ? `1px solid ${theme.colors.uiBlue}` : '1px solid transparent'}
+  border: ${({checked, theme}) => checked ? `1px solid ${theme.colors.dark}` : '1px solid transparent'}
 `;
 
 export default Label;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/LevelChoose/styled-components/Button.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/LevelChoose/styled-components/Button.js
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
 function dotColor(rank, theme) {
-    if(rank === 1)
-        return theme.colors.common;
-    if(rank === 2)
-        return theme.colors.gold;
-    if(rank === 3)
-        return theme.colors.epic;
+    if (rank === 1)
+        return theme.colors.greenyBluey;
+    if (rank === 2)
+        return theme.colors.yellowyOrangy;
+    if (rank === 3)
+        return theme.colors.purplyPinky;
 }
 
 const Button = styled.button`
@@ -18,24 +18,25 @@ const Button = styled.button`
           ({disabled}) => disabled ? "initial" : "pointer"
   };
   background-color: ${
-    ({theme, disabled}) => disabled ? theme.colors.ui04 : "transparent" 
+          ({theme, disabled}) => disabled ? theme.colors.lightGray : "transparent"
   };
   color: ${
-    ({theme, disabled}) => disabled ? theme.colors.borderLine : "initial"
+          ({theme, disabled}) => disabled ? theme.colors.dark : "initial"
   };
   position: relative;
   width: 100%;
   height: 100%;
   text-align: center;
-  
+
   transition: background-color 0.3s ease-in-out;
+
   &:hover {
     background-color: ${
-            ({theme, disabled}) => disabled ? theme.colors.ui04 : theme.colors.grey2
+            ({theme, disabled}) => disabled ? theme.colors.lightGray : theme.colors.lightGray
     };
   }
-  
-  
+
+
   :before {
     content: '';
     display: block;
@@ -45,7 +46,7 @@ const Button = styled.button`
     top: 14px;
     left: 30%;
     border-radius: 50%;
-    background-color: ${({rank, theme, disabled}) => disabled ? theme.colors.ui07trans : dotColor(rank, theme)};
+    background-color: ${({rank, theme, disabled}) => disabled ? theme.colors.darkTrans : dotColor(rank, theme)};
   }
 `;
 

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/LevelChoose/styled-components/Li.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/LevelChoose/styled-components/Li.js
@@ -6,7 +6,7 @@ const Li = styled.li`
   justify-content: center;
   align-items: center;
   border-radius: 4px;
-  background-color: ${({theme}) => theme.colors.grey1};
+  background-color: ${({theme}) => theme.colors.light2};
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
   width: 100%;
   height: 40px;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/LevelChoose/styled-components/Ul.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/LevelChoose/styled-components/Ul.js
@@ -15,7 +15,7 @@ const Ul = styled.ul`
   justify-content: center;
   align-items: center;
   animation: ${Animation} .6s ease-in-out;
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   border-radius: 10px;
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.15);
   border: none;

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/Levels/styled-components/CommonDiv.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/Levels/styled-components/CommonDiv.js
@@ -2,12 +2,12 @@ import styled from 'styled-components';
 import Div from './Div';
 
 const CommonDiv = styled(Div)`
-  background-color: ${({active, theme}) => active ? theme.colors.common : theme.colors.grey2};
-  color: ${({active, theme}) => active ? theme.colors.ui01 : theme.colors.ui07};
-  
+  background-color: ${({active, theme}) => active ? theme.colors.greenyBluey : theme.colors.lightGray};
+  color: ${({active, theme}) => active ? theme.colors.whiteAlmost : theme.colors.dark};
+
   @media (min-width: ${({theme}) => theme.overMobile}px) {
-    background-color: ${({exist, theme}) => exist ? theme.colors.common : theme.colors.grey2};
-    color: ${({theme}) => theme.colors.ui01};
+    background-color: ${({exist, theme}) => exist ? theme.colors.greenyBluey : theme.colors.lightGray};
+    color: ${({theme}) => theme.colors.whiteAlmost};
   }
 `;
 

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/Levels/styled-components/EpicDiv.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/Levels/styled-components/EpicDiv.js
@@ -2,12 +2,12 @@ import styled from 'styled-components';
 import Div from './Div';
 
 const EpicDiv = styled(Div)`
-  background-color: ${({active, theme}) => active ? theme.colors.epic : theme.colors.grey2};
-  color: ${({active, theme}) => active ? theme.colors.ui01 : theme.colors.borderLine};
+  background-color: ${({active, theme}) => active ? theme.colors.purplyPinky : theme.colors.lightGray};
+  color: ${({active, theme}) => active ? theme.colors.whiteAlmost : theme.colors.dark};
 
   @media (min-width: ${({theme}) => theme.overMobile}px) {
-    background-color: ${({exist, theme}) => exist ? theme.colors.epic : theme.colors.grey2};
-    color: ${({theme}) => theme.colors.ui01};
+    background-color: ${({exist, theme}) => exist ? theme.colors.purplyPinky : theme.colors.lightGray};
+    color: ${({theme}) => theme.colors.whiteAlmost};
   }
 `;
 

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/Levels/styled-components/GoldDiv.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/Levels/styled-components/GoldDiv.js
@@ -2,12 +2,12 @@ import styled from 'styled-components';
 import Div from './Div';
 
 const GoldDiv = styled(Div)`
-  background-color: ${({active, theme}) => active ? theme.colors.gold : theme.colors.grey2};
-  color: ${({active, theme}) => active ? theme.colors.ui01 : theme.colors.ui07};
+  background-color: ${({active, theme}) => active ? theme.colors.yellowyOrangy : theme.colors.lightGray};
+  color: ${({active, theme}) => active ? theme.colors.whiteAlmost : theme.colors.dark};
 
   @media (min-width: ${({theme}) => theme.overMobile}px) {
-    background-color: ${({exist, theme}) => exist ? theme.colors.gold : theme.colors.grey2};
-    color: ${({theme}) => theme.colors.ui01};
+    background-color: ${({exist, theme}) => exist ? theme.colors.yellowyOrangy : theme.colors.lightGray};
+    color: ${({theme}) => theme.colors.whiteAlmost};
   }
 `;
 

--- a/WMIAdventure/frontend/src/js/components/card-editor/atoms/TitleSection/styled-components/Div.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/atoms/TitleSection/styled-components/Div.js
@@ -5,7 +5,7 @@ const Div = styled.div`
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  color: ${({theme}) => theme.colors.ui01};
+  color: ${({theme}) => theme.colors.whiteAlmost};
   margin-bottom: 20px;
 `;
 

--- a/WMIAdventure/frontend/src/js/components/card-editor/molecules/CardChoose/styled-components/Ul.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/molecules/CardChoose/styled-components/Ul.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 const Ul = styled.ul`
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   display: flex;
   flex-direction: column;
 

--- a/WMIAdventure/frontend/src/js/components/card-editor/molecules/EffectChoose/styled-components/Ul.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/molecules/EffectChoose/styled-components/Ul.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 const Ul = styled.ul`
   display: flex;
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   flex-direction: column;
   
   width: 80%;

--- a/WMIAdventure/frontend/src/js/components/card-editor/molecules/EffectsInputsList/styled-components/P.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/molecules/EffectsInputsList/styled-components/P.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 const P = styled.p`
   font-size: 16px;
   margin: 0 0 0 8px;
-  color: ${({theme}) => theme.colors.borderLine};
+  color: ${({theme}) => theme.colors.dark};
 `;
 
 export default P;

--- a/WMIAdventure/frontend/src/js/components/card-editor/molecules/SendCardPopup/styled-components/PopupContainer.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/molecules/SendCardPopup/styled-components/PopupContainer.js
@@ -17,7 +17,7 @@ const PopupContainer = styled.div`
   z-index: 3;
   
   /* Styling */
-  background: ${({theme}) => theme.colors.ui01};
+  background: ${({theme}) => theme.colors.whiteAlmost};
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.15);
   border-radius: 10px;
 `;

--- a/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardProperties/styled-components/DivLevel.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardProperties/styled-components/DivLevel.js
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
 function activeRankBorderHandler(activeCardRank, theme) {
-    if(activeCardRank === 1)
-        return `4px solid ${theme.colors.common}`;
-    if(activeCardRank === 2)
-        return `4px solid ${theme.colors.gold}`;
-    if(activeCardRank === 3)
-        return `4px solid ${theme.colors.epic}`;
+    if (activeCardRank === 1)
+        return `4px solid ${theme.colors.greenyBluey}`;
+    if (activeCardRank === 2)
+        return `4px solid ${theme.colors.yellowyOrangy}`;
+    if (activeCardRank === 3)
+        return `4px solid ${theme.colors.purplyPinky}`;
     return '4px solid transparent';
 }
 
@@ -21,15 +21,16 @@ const DivLevel = styled.div`
   height: 38px;
   border-bottom-left-radius: 20px;
   border-bottom-right-radius: 20px;
-  background-color: ${({theme}) => theme.colors.grey2};
+  background-color: ${({theme}) => theme.colors.lightGray};
   border-bottom: ${({activeCardRank, theme}) => activeRankBorderHandler(activeCardRank, theme)};
   border-left: ${({activeCardRank, theme}) => activeRankBorderHandler(activeCardRank, theme)};
   border-right: ${({activeCardRank, theme}) => activeRankBorderHandler(activeCardRank, theme)};
-  
+
   overflow-x: scroll;
   overflow-y: hidden;
   scrollbar-width: thin;
   -ms-overflow-style: none; /* IE 10+ */
+
   ::-webkit-scrollbar {
     display: none; /* Chrome Safari */
   }

--- a/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardProperties/styled-components/Fieldset.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardProperties/styled-components/Fieldset.js
@@ -1,28 +1,28 @@
 import styled from 'styled-components';
 
 function activeRankHandler(activeCardRank, theme) {
-    if(activeCardRank === 1)
-        return `4px solid ${theme.colors.common}`;
-    if(activeCardRank === 2)
-        return `4px solid ${theme.colors.gold}`;
-    if(activeCardRank === 3)
-        return `4px solid ${theme.colors.epic}`;
+    if (activeCardRank === 1)
+        return `4px solid ${theme.colors.greenyBluey}`;
+    if (activeCardRank === 2)
+        return `4px solid ${theme.colors.yellowyOrangy}`;
+    if (activeCardRank === 3)
+        return `4px solid ${theme.colors.purplyPinky}`;
     return '4px solid transparent';
 }
 
 function createLevelHandler(createCommon, createGold, createEpic, theme) {
-    if(createCommon)
-        return `4px solid ${theme.colors.common}`;
-    if(createGold)
-        return `4px solid ${theme.colors.gold}`;
-    if(createEpic)
-        return `4px solid ${theme.colors.epic}`;
+    if (createCommon)
+        return `4px solid ${theme.colors.greenyBluey}`;
+    if (createGold)
+        return `4px solid ${theme.colors.yellowyOrangy}`;
+    if (createEpic)
+        return `4px solid ${theme.colors.purplyPinky}`;
     return '4px solid transparent';
 }
 
 const Fieldset = styled.fieldset`
   width: 100%;
-  
+
   @media (max-height: 568px) {
     height: 220px;
   }
@@ -34,7 +34,7 @@ const Fieldset = styled.fieldset`
   @media (max-height: 800px) {
     height: 400px;
   }
-  
+
   @media (min-height: 800px) {
     height: 482px;
   }
@@ -42,7 +42,7 @@ const Fieldset = styled.fieldset`
   @media (min-height: 900px) {
     height: 532px;
   }
-  
+
   border-top-left-radius: 20px;
   border-top-right-radius: 20px;
   border: none;
@@ -52,9 +52,9 @@ const Fieldset = styled.fieldset`
   position: relative;
   padding: 16px;
   margin: 0 0 52px 0;
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   border: ${({activeCardRank, theme}) => activeRankHandler(activeCardRank, theme)};
-  
+
   @media (min-height: 800px) {
     margin: 0 0 64px 0;
   }
@@ -67,7 +67,7 @@ const Fieldset = styled.fieldset`
     margin: 0 6px 24px;
     padding: 0;
     display: ${({create}) => create ? 'flex' : 'none'};
-    border: ${({createCommon, createGold, createEpic, theme}) => 
+    border: ${({createCommon, createGold, createEpic, theme}) =>
             createLevelHandler(createCommon, createGold, createEpic, theme)};
   }
 `;

--- a/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardView/styled-components/Button.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardView/styled-components/Button.js
@@ -1,27 +1,27 @@
 import styled from 'styled-components';
 
 function colorHandler(theme, access, activeCommon, activeGold, activeEpic) {
-    if(activeCommon || activeGold || activeEpic)
-        return theme.colors.ui01;
-    if(access)
-        return theme.colors.ui07;
+    if (activeCommon || activeGold || activeEpic)
+        return theme.colors.whiteAlmost;
+    if (access)
+        return theme.colors.dark;
     else
-        return theme.colors.grey3;
+        return theme.colors.darkGray;
 }
 
 function backgroundHandler(theme, access, activeCommon, activeGold, activeEpic) {
 
-    if(activeEpic)
-        return theme.colors.epic;
-    else if(activeGold)
-        return theme.colors.gold;
-    else if(activeCommon)
-        return theme.colors.common;
+    if (activeEpic)
+        return theme.colors.purplyPinky;
+    else if (activeGold)
+        return theme.colors.yellowyOrangy;
+    else if (activeCommon)
+        return theme.colors.greenyBluey;
 
-    if(access)
-        return theme.colors.grey1;
+    if (access)
+        return theme.colors.light2;
     else
-        return theme.colors.grey2;
+        return theme.colors.lightGray;
 }
 
 const Button = styled.button`
@@ -35,9 +35,21 @@ const Button = styled.button`
   padding: 0;
   margin: 0;
   border: none;
-  color: ${({theme, access, activeCommon, activeGold, activeEpic}) => colorHandler(theme, access, activeCommon, activeGold, activeEpic)};
-  background-color: ${({theme, access, activeCommon, activeGold, activeEpic}) => backgroundHandler(theme, access, activeCommon, activeGold, activeEpic)};
-  //background-color: ${({access, theme}) => access ? theme.colors.grey1 : theme.colors.grey2};
+  color: ${({
+              theme,
+              access,
+              activeCommon,
+              activeGold,
+              activeEpic
+            }) => colorHandler(theme, access, activeCommon, activeGold, activeEpic)};
+  background-color: ${({
+                         theme,
+                         access,
+                         activeCommon,
+                         activeGold,
+                         activeEpic
+                       }) => backgroundHandler(theme, access, activeCommon, activeGold, activeEpic)};
+    //background-color: ${({access, theme}) => access ? theme.colors.light2 : theme.colors.lightGray};
 `;
 
 export default Button;

--- a/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardView/styled-components/MobileLevelsMenu.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardView/styled-components/MobileLevelsMenu.js
@@ -7,7 +7,7 @@ const MobileLevelsMenu = styled.div`
   left: 0;
   width: 100%;
   height: 40px;
-  background-color: ${({theme}) => theme.colors.grey1};
+  background-color: ${({theme}) => theme.colors.light2};
 `;
 
 export default MobileLevelsMenu;

--- a/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/styled-components/Button.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/styled-components/Button.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 function showHandler(show) {
-    if(show === 'create')
+    if (show === 'create')
         return 'none';
     else if (show === 'edit' || show === true)
         return 'block';
@@ -10,8 +10,8 @@ function showHandler(show) {
 const Button = styled.button`
   display: ${({show}) => showHandler(show)};
   background-color: transparent;
-  color: ${({theme, access}) => access ? theme.colors.ui01 : theme.colors.grey2};
-  border: 2px solid ${({theme, access}) => access ? theme.colors.ui01 : theme.colors.grey2};
+  color: ${({theme, access}) => access ? theme.colors.whiteAlmost : theme.colors.lightGray};
+  border: 2px solid ${({theme, access}) => access ? theme.colors.whiteAlmost : theme.colors.lightGray};
   filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
   border-radius: 10px;
   padding: 12px;

--- a/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/styled-components/Main.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/styled-components/Main.js
@@ -10,7 +10,7 @@ const Main = styled.main`
   padding: 20px 16px;
   border-top-left-radius: 20px;
   border-top-right-radius: 20px;
-  background-color: ${({theme}) => theme.colors.uiBlue};
+  background-color: ${({theme}) => theme.colors.dark};
 `;
 
 export default Main;

--- a/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/styled-components/Div.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/styled-components/Div.js
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
 function colorHandler(common, gold, epic) {
-    if(common)
-        return ({theme}) => theme.colors.common;
-    else if(gold)
-        return ({theme}) => theme.colors.gold;
-    else if(epic)
-        return ({theme}) => theme.colors.epic;
+    if (common)
+        return ({theme}) => theme.colors.greenyBluey;
+    else if (gold)
+        return ({theme}) => theme.colors.yellowyOrangy;
+    else if (epic)
+        return ({theme}) => theme.colors.purplyPinky;
 }
 
 const Div = styled.div`
@@ -16,7 +16,7 @@ const Div = styled.div`
   justify-content: space-between;
   width: ${({setWidth}) => setWidth ? setWidth : '114px'};
   height: ${({setHeight}) => setHeight ? setHeight : '182px'};
-  background-color: ${({theme}) => theme.colors.grey1};
+  background-color: ${({theme}) => theme.colors.light2};
   border-radius: 8px;
   position: relative;
   margin: ${({setMargin}) => setMargin ? setMargin : '0 0 60px 0'};
@@ -40,7 +40,11 @@ const Div = styled.div`
     left: 0;
     width: 100%;
     height: ${({decorationHeight}) => decorationHeight ? decorationHeight : '20px'};
-    border-top: ${({decorationHeight}) => decorationHeight ? decorationHeight : '22px'} solid ${({common, gold, epic}) => colorHandler(common, gold, epic)};
+    border-top: ${({decorationHeight}) => decorationHeight ? decorationHeight : '22px'} solid ${({
+                                                                                                   common,
+                                                                                                   gold,
+                                                                                                   epic
+                                                                                                 }) => colorHandler(common, gold, epic)};
     border-top-left-radius: 12px;
     border-top-right-radius: 12px;
   }

--- a/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/styled-components/Name.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/styled-components/Name.js
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
 
 function nameLengthHandler(nameLength, ownFontSize) {
-    if(ownFontSize)
+    if (ownFontSize)
         return ownFontSize;
-    if(nameLength < 20) {
+    if (nameLength < 20) {
         return '20px';
-    } return '16px';
+    }
+    return '16px';
 }
 
 const Name = styled.p`
@@ -14,7 +15,7 @@ const Name = styled.p`
   text-align: center;
   text-transform: uppercase;
   font-weight: ${({theme}) => theme.weight.semibold};
-  color: ${({theme}) => theme.colors.borderLine};
+  color: ${({theme}) => theme.colors.dark};
   overflow-wrap: anywhere;
   max-width: 120px;
 `;

--- a/WMIAdventure/frontend/src/js/components/global/atoms/FullCardView/styled-components/Article.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/FullCardView/styled-components/Article.js
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
 function colorHandler(common, gold, epic) {
-    if(common)
-        return ({theme}) => theme.colors.common;
-    else if(gold)
-        return ({theme}) => theme.colors.gold;
-    else if(epic)
-        return ({theme}) => theme.colors.epic;
+    if (common)
+        return ({theme}) => theme.colors.greenyBluey;
+    else if (gold)
+        return ({theme}) => theme.colors.yellowyOrangy;
+    else if (epic)
+        return ({theme}) => theme.colors.purplyPinky;
 }
 
 const Article = styled.article`
@@ -16,18 +16,18 @@ const Article = styled.article`
   justify-content: center;
   width: 262px;
   height: 464px;
-  background-color: ${({theme}) => theme.colors.grey1};
+  background-color: ${({theme}) => theme.colors.light2};
   margin-bottom: 14px;
   border-radius: 24px;
   position: relative;
   overflow-y: hidden;
   font-family: 'Roboto', sans-serif;
-  
+
   @media (min-width: ${({theme}) => theme.overMobile}px) {
     width: 300px;
     height: 500px;
   }
-  
+
   &:before {
     content: '';
     display: block;

--- a/WMIAdventure/frontend/src/js/components/global/atoms/FullCardView/styled-components/Category.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/FullCardView/styled-components/Category.js
@@ -5,7 +5,7 @@ const Category = styled.p`
   font-weight: ${({theme}) => theme.weight.regular};
   text-transform: uppercase;
   margin: 0;
-  color: ${({theme}) => theme.colors.borderLine};
+  color: ${({theme}) => theme.colors.dark};
   text-align: center;
   overflow-wrap: anywhere;
   max-width: 200px;

--- a/WMIAdventure/frontend/src/js/components/global/atoms/FullCardView/styled-components/H3.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/FullCardView/styled-components/H3.js
@@ -4,34 +4,36 @@ import lvlIconGold from '../../../../../../assets/icons/lvlIconGold.svg';
 import lvlIconEpic from '../../../../../../assets/icons/lvlIconEpic.svg';
 
 function iconHandler(common, gold, epic) {
-    if(common)
+    if (common)
         return lvlIconCommon;
-    else if(gold)
+    else if (gold)
         return lvlIconGold;
-    else if(epic)
+    else if (epic)
         return lvlIconEpic;
 }
 
 function iconHeightHandler(common, gold, epic) {
-    if(common)
+    if (common)
         return '15px';
-    else if(gold)
+    else if (gold)
         return '22px';
-    else if(epic)
+    else if (epic)
         return '31px';
 }
 
 function nameLengthHandler(nameLength) {
-    if(nameLength < 20) {
+    if (nameLength < 20) {
         return '32px';
-    } return '16px';
-}
-function nameLineHeightHandler(nameLength) {
-    if(nameLength < 20) {
-        return '36px';
-    } return '20px';
+    }
+    return '16px';
 }
 
+function nameLineHeightHandler(nameLength) {
+    if (nameLength < 20) {
+        return '36px';
+    }
+    return '20px';
+}
 
 
 const H3 = styled.h3`
@@ -43,7 +45,7 @@ const H3 = styled.h3`
   line-height: ${({nameLength}) => nameLineHeightHandler(nameLength)};
   overflow-wrap: anywhere;
   max-width: 200px;
-  color: ${({theme}) => theme.colors.borderLine};
+  color: ${({theme}) => theme.colors.dark};
   
   &:before {
     content: '';

--- a/WMIAdventure/frontend/src/js/components/global/atoms/FullCardView/styled-components/Tooltip.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/FullCardView/styled-components/Tooltip.js
@@ -3,13 +3,13 @@ import styled from 'styled-components';
 const Tooltip = styled.p`
   margin: 0 0 20px 0;
   font-size: 12px;
-  color: ${({theme}) => theme.colors.borderLine};
+  color: ${({theme}) => theme.colors.dark};
   font-weight: ${({theme}) => theme.weight.regular};
   font-style: italic;
   text-transform: uppercase;
   max-width: 200px;
   text-align: center;
-  color: ${({theme}) => theme.colors.borderLine};
+  color: ${({theme}) => theme.colors.dark};
   overflow-wrap: anywhere;
   padding: 0 6px;
 `;

--- a/WMIAdventure/frontend/src/js/components/global/atoms/LoadingPopUp/styled-components/P.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/LoadingPopUp/styled-components/P.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 const P = styled.p`
   margin: 0;
   text-transform: uppercase;
-  color: ${({theme}) => theme.colors.uiBlue};
+  color: ${({theme}) => theme.colors.dark};
   font-weight: ${({theme}) => theme.weight.medium};
   font-size: 18px;
 `;

--- a/WMIAdventure/frontend/src/js/components/global/atoms/LoadingPopUp/styled-components/View.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/LoadingPopUp/styled-components/View.js
@@ -4,7 +4,7 @@ const View = styled.h2`
   font-family: 'Roboto', sans-serif;
   font-size: 28px;
   font-weight: ${({theme}) => theme.weight.medium};
-  color: ${({theme}) => theme.colors.uiBlue};
+  color: ${({theme}) => theme.colors.dark};
   text-transform: uppercase;
   margin: 0 0 36px 0;
   

--- a/WMIAdventure/frontend/src/js/components/global/atoms/Search/styled-components/Input.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/Search/styled-components/Input.js
@@ -6,7 +6,7 @@ const Input = styled.input`
   width: 100%;
   margin: 2px 0 0 32px;
   ::placeholder {
-    color: ${({theme}) => theme.colors.grey2};
+    color: ${({theme}) => theme.colors.lightGray};
     font-size: 14px;
   }
 `;

--- a/WMIAdventure/frontend/src/js/components/global/atoms/Search/styled-components/P.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/Search/styled-components/P.js
@@ -8,7 +8,7 @@ const P = styled.p`
   justify-content: center;
   align-items: center;
   width: 100%;
-  border-bottom: 1px solid ${({theme}) => theme.colors.borderLine};
+  border-bottom: 1px solid ${({theme}) => theme.colors.dark};
   position: relative;
   
   ::before {

--- a/WMIAdventure/frontend/src/js/components/global/organisms/PopUp/styled-components/Div.js
+++ b/WMIAdventure/frontend/src/js/components/global/organisms/PopUp/styled-components/Div.js
@@ -11,7 +11,7 @@ const Div = styled.div`
   left: 0;
   height: calc(100vh - 48px);
   width: 100%;
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   transition: opacity 0.3s ease-in-out, transform  0.3s ease-in-out;
   z-index: 5;
   overflow-y: scroll;

--- a/WMIAdventure/frontend/src/js/components/global/organisms/TransBack/styled-components/Div.js
+++ b/WMIAdventure/frontend/src/js/components/global/organisms/TransBack/styled-components/Div.js
@@ -11,7 +11,7 @@ const Div = styled.div`
   left: 0;
   height: calc(100vh - 48px);
   width: 100%;
-  background-color: ${({theme}) => theme.colors.ui07trans};
+  background-color: ${({theme}) => theme.colors.darkTrans};
 `;
 
 export default Div;

--- a/WMIAdventure/frontend/src/js/components/prototype/atoms/CardPreview/styled-components/Article.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/atoms/CardPreview/styled-components/Article.js
@@ -7,12 +7,12 @@ const Article = styled.article`
   align-items: center;
   width: 120px;
   height: 160px;
-  background-color: ${({theme}) => theme.colors.ui05};
+  background-color: ${({theme}) => theme.colors.lightGray};
   border-radius: 12px;
-  border: 2px solid ${({theme}) => theme.colors.hoverprimary};
+  border: 2px solid ${({theme}) => theme.colors.greenyBluey};
   padding: 12px;
   margin: 0 12px 8px;
-  
+
   @media (min-width: 440px) {
     width: 130px;
     height: 190px;
@@ -22,7 +22,7 @@ const Article = styled.article`
   @media (min-width: ${({theme}) => theme.overMobile}px) {
     margin: 0 128px 12px;
   }
-  
+
   @media (min-width: 1200px) {
     margin: 0 8px 12px;
   }

--- a/WMIAdventure/frontend/src/js/components/prototype/atoms/CardPreview/styled-components/H4.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/atoms/CardPreview/styled-components/H4.js
@@ -5,7 +5,7 @@ const H4 = styled.h4`
   font-weight: 600;
   margin: 0 0 4px 0;
   text-align: center;
-  color: ${({theme}) => theme.colors.text01};
+  color: ${({theme}) => theme.colors.dark};
 
   @media (min-width: 440px) {
     font-size: 16px;

--- a/WMIAdventure/frontend/src/js/components/prototype/atoms/FightButton/styled-components/Button.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/atoms/FightButton/styled-components/Button.js
@@ -6,12 +6,12 @@ const Button = styled.button`
   margin: 0 12px 0 0;
   font-size: 14px;
   font-weight: 600;
-  background-color: ${({theme}) => theme.colors.ui05};
+  background-color: ${({theme}) => theme.colors.lightGray};
   cursor: pointer;
   border: none;
   border-radius: 4px;
   position: relative;
-  
+
   // :before {
   //   content: '';
   //   display: block;
@@ -20,7 +20,7 @@ const Button = styled.button`
   //   left: 2px;
   //   width: 18px;
   //   height: 28px;
-  //   background-image: url(${thunderIcon});
+    //   background-image: url(${thunderIcon});
   //   background-repeat: no-repeat;
   //   background-position: center;
   // }

--- a/WMIAdventure/frontend/src/js/components/prototype/atoms/Logo/styled-components/Link.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/atoms/Logo/styled-components/Link.js
@@ -4,7 +4,7 @@ import {Link} from 'react-router-dom';
 const A = styled(Link)`
   display: flex;
   align-items: center;
-  color: ${({theme}) => theme.colors.text01};
+  color: ${({theme}) => theme.colors.dark};
   text-decoration: none;
 `;
 

--- a/WMIAdventure/frontend/src/js/components/prototype/atoms/MainMenuModule/styled-components/Describe.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/atoms/MainMenuModule/styled-components/Describe.js
@@ -7,10 +7,10 @@ const Describe = styled.p`
   justify-content: center;
   font-size: 16px;
   font-weight: 400;
-  color: ${({theme}) => theme.colors.ui07};
+  color: ${({theme}) => theme.colors.dark};
   text-align: center;
   margin: 0;
-  
+
   @media (min-width: ${({theme}) => theme.overMobile}px) {
     font-size: 18px;
     height: 100%;

--- a/WMIAdventure/frontend/src/js/components/prototype/atoms/MainMenuModule/styled-components/Wrapper.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/atoms/MainMenuModule/styled-components/Wrapper.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import {Link} from 'react-router-dom';
 
 const Wrapper = styled(Link)`
-  background-color: ${({theme}) => theme.colors.ui05};
+  background-color: ${({theme}) => theme.colors.lightGray};
   color: ${({theme}) => theme.colors.ui06};
   width: 100%;
   height: 124px;
@@ -15,7 +15,7 @@ const Wrapper = styled(Link)`
   position: relative;
   text-decoration: none;
   overflow: hidden;
-  
+
   @media (min-width: ${({theme}) => theme.overMobile}px) {
     flex-direction: row;
     justify-content: space-between;

--- a/WMIAdventure/frontend/src/js/components/prototype/atoms/MainMenuSmallerModule/styled-components/Wrapper.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/atoms/MainMenuSmallerModule/styled-components/Wrapper.js
@@ -4,10 +4,10 @@ import {Link} from 'react-router-dom';
 const Wrapper = styled(Link)`
   border-bottom-right-radius: 30px;
   border-top-left-radius: 30px;
-  border: 2px solid ${({theme}) => theme.colors.gold};
+  border: 2px solid ${({theme}) => theme.colors.yellowyOrangy};
   height: 72px;
   width: 120px;
-  background-color: ${({theme}) => theme.colors.ui05};
+  background-color: ${({theme}) => theme.colors.lightGray};
   position: relative;
   display: flex;
   justify-content: center;
@@ -15,9 +15,9 @@ const Wrapper = styled(Link)`
   color: ${({theme}) => theme.colors.ui06};
   text-decoration: none;
   margin: 0 6px 16px 6px;
-  
+
   @media (min-width: ${({theme}) => theme.overMobile}px) {
-    border: 7px solid ${({theme}) => theme.colors.gold};
+    border: 7px solid ${({theme}) => theme.colors.yellowyOrangy};
     height: 124px;
     width: 336px;
   }

--- a/WMIAdventure/frontend/src/js/components/prototype/atoms/MoreOptions/styled-components/List.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/atoms/MoreOptions/styled-components/List.js
@@ -5,7 +5,7 @@ const List = styled.ul`
   position: absolute;
   top: 16px;
   right: 16px;
-  background-color: ${({theme}) => theme.colors.ui04};
+  background-color: ${({theme}) => theme.colors.lightGray};
   border-radius: 10px;
   z-index: 3;
   margin: 0;

--- a/WMIAdventure/frontend/src/js/components/prototype/atoms/MoreOptions/styled-components/Paragraph.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/atoms/MoreOptions/styled-components/Paragraph.js
@@ -2,9 +2,9 @@ import styled from 'styled-components';
 
 const Paragraph = styled.a`
   text-decoration: none;
-  color: ${({theme}) => theme.colors.ui07};
+  color: ${({theme}) => theme.colors.dark};
   margin: ${({last}) => last ? '0' : '0 0 10px 0'};
-  border-bottom: ${({border}) => border ? `1px solid ${({theme}) => theme.colors.ui07}` : 'none'};
+  border-bottom: ${({border}) => border ? `1px solid ${({theme}) => theme.colors.dark}` : 'none'};
   padding: ${({border}) => border ? '0 0 10px 0' : '0'};
   display: block;
   text-align: center;

--- a/WMIAdventure/frontend/src/js/components/prototype/atoms/MoreOptions/styled-components/Wrapper.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/atoms/MoreOptions/styled-components/Wrapper.js
@@ -7,8 +7,8 @@ const Wrapper = styled.div`
   top: 48px;
   width: 100vw;
   height: calc(100vh - 48px);
-  background-color: ${({theme}) => theme.colors.ui07trans};
-  
+  background-color: ${({theme}) => theme.colors.darkTrans};
+
   @media (min-width: ${({theme}) => theme.overMobile}px) {
     height: calc(100vh - 64px);
     top: 64px;

--- a/WMIAdventure/frontend/src/js/components/prototype/atoms/NavMenu/styled-components/Li.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/atoms/NavMenu/styled-components/Li.js
@@ -4,9 +4,9 @@ const Li = styled.li`
   font-size: 18px;
   font-weight: 700;
   text-align: center;
-  
+
   a {
-    color: ${({theme}) => theme.colors.ui07};
+    color: ${({theme}) => theme.colors.dark};
     text-decoration: none;
   }
 `

--- a/WMIAdventure/frontend/src/js/components/prototype/atoms/NavMenu/styled-components/Ul.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/atoms/NavMenu/styled-components/Ul.js
@@ -11,7 +11,7 @@ const Animation = keyframes`
 
 const Ul = styled.ul`
   animation: ${Animation} .5s ease-in-out;
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   margin: 0;
   list-style: none;
   width: 100%;

--- a/WMIAdventure/frontend/src/js/components/prototype/atoms/ProfileButton/styled-components/Wrapper.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/atoms/ProfileButton/styled-components/Wrapper.js
@@ -5,7 +5,7 @@ const Wrapper = styled(Link)`
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   border: none;
   border-radius: 50%;
   width: 32px;

--- a/WMIAdventure/frontend/src/js/components/prototype/molecules/BattleResult/styled-components/Back.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/molecules/BattleResult/styled-components/Back.js
@@ -3,12 +3,12 @@ import styled from 'styled-components';
 const Back = styled.button`
   border: none;
   border-radius: 10px;
-  background-color: ${({theme}) => theme.colors.ui04};
+  background-color: ${({theme}) => theme.colors.lightGray};
   padding: 6px 12px;
   margin: 12px 0;
   font-size: 16px;
   cursor: pointer;
-  
+
   @media (min-width: ${({theme}) => theme.overMobile}px) {
     font-size: 24px;
     padding: 12px 24px;

--- a/WMIAdventure/frontend/src/js/components/prototype/molecules/BattleResult/styled-components/Wrapper.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/molecules/BattleResult/styled-components/Wrapper.js
@@ -6,14 +6,14 @@ const Wrapper = styled.div`
   left: 0;
   width: 100%;
   min-height: calc(100vh - 48px);
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   padding: 16px 0;
-  
-  @media(min-width: ${({theme}) => theme.overMobile}px) {
+
+  @media (min-width: ${({theme}) => theme.overMobile}px) {
     min-height: calc(100vh - 64px);
     top: 64px;
   }

--- a/WMIAdventure/frontend/src/js/components/prototype/molecules/NotificationButton/styled-components/Wrapper.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/molecules/NotificationButton/styled-components/Wrapper.js
@@ -6,7 +6,7 @@ const Wrapper = styled.button`
   align-items: center;
   cursor: pointer;
 
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   border: none;
   border-radius: 50%;
   width: 32px;

--- a/WMIAdventure/frontend/src/js/components/prototype/molecules/Notifications/StyledNotifications/Item.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/molecules/Notifications/StyledNotifications/Item.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 const Item = styled.li`
-  background-color: ${({theme}) => theme.colors.ui03};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   border-radius: 10px;
   padding: 12px;
 `;

--- a/WMIAdventure/frontend/src/js/components/prototype/molecules/Notifications/StyledNotifications/List.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/molecules/Notifications/StyledNotifications/List.js
@@ -8,7 +8,7 @@ const List = styled.ul`
   margin: 0;
   padding: 8px;
   list-style: none;
-  background-color: ${({theme}) => theme.colors.ui04};
+  background-color: ${({theme}) => theme.colors.lightGray};
   display: grid;
   grid-template-columns: auto;
   grid-row-gap: 8px;

--- a/WMIAdventure/frontend/src/js/components/prototype/molecules/Notifications/StyledNotifications/StyledNotifications.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/molecules/Notifications/StyledNotifications/StyledNotifications.js
@@ -10,7 +10,7 @@ const StyledNotifications = styled.div`
   left: 0;
   width: 100vw;
   height: calc(100vh - 64px);
-  background-color: ${({theme}) => theme.colors.ui07trans};
+  background-color: ${({theme}) => theme.colors.darkTrans};
 `;
 
 StyledNotifications.Header = Header;

--- a/WMIAdventure/frontend/src/js/components/prototype/molecules/ShowMoreButton/styled-components/Wrapper.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/molecules/ShowMoreButton/styled-components/Wrapper.js
@@ -6,7 +6,7 @@ const Wrapper = styled.button`
   align-items: center;
   cursor: pointer;
 
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   border: none;
   border-radius: 50%;
   width: 32px;

--- a/WMIAdventure/frontend/src/js/components/prototype/molecules/UserToFight/styled-components/Li.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/molecules/UserToFight/styled-components/Li.js
@@ -6,10 +6,10 @@ const Li = styled.li`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background-color: ${({theme}) => theme.colors.ui03};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   border-radius: 10px;
   margin-bottom: 16px;
-  border: 2px solid ${({theme}) => theme.colors.gold};
+  border: 2px solid ${({theme}) => theme.colors.yellowyOrangy};
 `;
 
 export default Li;

--- a/WMIAdventure/frontend/src/js/components/prototype/organisms/NavBar/StyledNavBar/StyledNavBar.js
+++ b/WMIAdventure/frontend/src/js/components/prototype/organisms/NavBar/StyledNavBar/StyledNavBar.js
@@ -3,14 +3,14 @@ import IconsWrapper from './IconsWrapper';
 import Navigation from './Navigation';
 
 const StyledNavBar = styled.header`
-  background-color: ${({theme}) => theme.colors.ui04};
+  background-color: ${({theme}) => theme.colors.lightGray};
   width: 100%;
   height: 48px;
   position: fixed;
   top: 0;
   left: 0;
   z-index: 13;
-  
+
   @media (min-width: ${({theme}) => theme.overMobile}px) {
     height: 64px;
   }

--- a/WMIAdventure/frontend/src/js/pages/BattleMode/styled-components/H2.js
+++ b/WMIAdventure/frontend/src/js/pages/BattleMode/styled-components/H2.js
@@ -13,7 +13,7 @@ const H2 = styled.h2`
     font-family: 'Roboto', sans-serif;
     font-weight: ${({theme}) => theme.weight.regular};
     font-size: 48px;
-    color: ${({theme}) => theme.colors.ui01};
+    color: ${({theme}) => theme.colors.whiteAlmost};
     letter-spacing: 3px;
     order: 3;
   }

--- a/WMIAdventure/frontend/src/js/pages/BattleMode/styled-components/Main.js
+++ b/WMIAdventure/frontend/src/js/pages/BattleMode/styled-components/Main.js
@@ -6,11 +6,11 @@ const Main = styled.main`
   grid-auto-columns: 1fr;
   padding: 0 12px;
   height: 100vh;
-  background-color: ${({theme}) => theme.colors.uiGreen};
+  background-color: ${({theme}) => theme.colors.greenyBluey};
   overflow: hidden;
   position: relative;
 
-  @media(min-width: ${({theme}) => theme.overMobile}px) {
+  @media (min-width: ${({theme}) => theme.overMobile}px) {
     display: flex;
     justify-content: space-around;
     align-items: center;

--- a/WMIAdventure/frontend/src/js/pages/BattleMode/styled-components/SearchContainer.js
+++ b/WMIAdventure/frontend/src/js/pages/BattleMode/styled-components/SearchContainer.js
@@ -6,7 +6,7 @@ const SearchContainer = styled.div`
   margin: 0 auto;
   border-top-left-radius: 20px;
   border-top-right-radius: 20px;
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   padding: 0 10px;
 
   @media(min-width: ${({theme}) => theme.overMobile}px) {

--- a/WMIAdventure/frontend/src/js/pages/BattleMode/styled-components/Title.js
+++ b/WMIAdventure/frontend/src/js/pages/BattleMode/styled-components/Title.js
@@ -5,7 +5,7 @@ const Title = styled.p`
   font-size: 80px;
   font-weight: ${({theme}) => theme.weight.bold};
   letter-spacing: 18px;
-  color: ${({theme}) => theme.colors.ui01};
+  color: ${({theme}) => theme.colors.whiteAlmost};
   text-transform: uppercase;
   order: 1;
 

--- a/WMIAdventure/frontend/src/js/pages/BattleMode/styled-components/Ul.js
+++ b/WMIAdventure/frontend/src/js/pages/BattleMode/styled-components/Ul.js
@@ -7,7 +7,7 @@ const Ul = styled.ul`
   list-style: none;
   margin: 0 auto 92px;
   padding: 0 10px 10px;
-  background-color: ${({theme}) => theme.colors.ui01};
+  background-color: ${({theme}) => theme.colors.whiteAlmost};
   border-bottom-left-radius: 20px;
   border-bottom-right-radius: 20px;
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);

--- a/WMIAdventure/frontend/src/js/pages/CardsCreatorStart/styled-components/Main.js
+++ b/WMIAdventure/frontend/src/js/pages/CardsCreatorStart/styled-components/Main.js
@@ -5,13 +5,13 @@ const Main = styled.main`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  
+
   width: 100%;
   min-height: calc(100vh - 56px);
   padding: 16px;
   border-top-left-radius: 20px;
   border-top-right-radius: 20px;
-  background-color: ${({theme}) => theme.colors.uiGreen};
+  background-color: ${({theme}) => theme.colors.greenyBluey};
 `;
 
 export default Main;

--- a/WMIAdventure/frontend/src/js/utils/colors.js
+++ b/WMIAdventure/frontend/src/js/utils/colors.js
@@ -1,60 +1,20 @@
 const colors = {
-    available: '#4C7D5A',
-    unavailable: '#CC5C5C',
 
-    // Brand
+    // Prototype colours: TODO: Remove after all prototype views are gone
     brand01: '#121232',
-    brand02: '#4E4E5A',
-    $brand03: '#727279',
-
-    // New text
-    new_text01: '#333333',
-
-    // Text
-    text01: '#232735',
-    text02: '#505565',
-    text03: '#8B90A0',
-    textInverse: '#FFFFFF',
-
-    // UI
-    ui01: '#FFFFFF',
-    ui02: '#FAFAFC',
-    ui03: '#F0F1F3',
-    ui04: '#D3D4D8',
-    ui05: '#A1A4B1',
     ui06: '#232735',
-    ui07: '#000000',
 
-    ui07trans: '#24343766',
-
-    // Hover
-    hoverprimary: '#3E465F',
-    hoverrow: '#EEEEF1',
-
-
-    // Card Editor
-    uiGreen: '#13876F',
-    uiBlue: '#243437',
-    transBack: '#00000044',
-
-    common: '#13876F',
-    gold: '#F2C94C',
-    cardGold: '#F2C94C',
-    epic: '#BB6BD9',
-    cardEpic: '#4D15EA',
-
-    grey1: '#F2F2F2',
-    grey2: '#E0E0E0',
-    grey3: '#828282',
-    borderLine: '#243437',
-
-
-    // new colors
-    red: '#DB4E4E',
+    whiteAlmost: '#FDFDFD',
     light2: '#F7F7F7',
-    darkgrey: '#282829',
-    userItemHover: '#E5E5E5',
-    lightGray2: '#B2AFAF',
+    lightGray: '#E0E0E0',
+    darkGray: '#B2AFAF',
+    dark: '#243437',
+    darkTrans: '#24343766',
+    transBack: '#00000044',
+    greenyBluey: '#13876F',
+    yellowyOrangy: '#F2C94C',
+    purplyPinky: '#9B51E0',
+    red: '#DB4E4E',
 };
 
 export default colors;


### PR DESCRIPTION
Closes #544 
Prototypowe widoki mogą być trochę broken, ale chciałem wyrzucić jak najwięcej z tych starych kolorów.
Zostały tylko dwa z prototypów i dwa z jakąś transparentnością.
Pozmieniałem trochę te nazwy kolorów żeby były bardziej intuicyjne. Na Figmie wszystko jest tak samo.