### PR TITLE
Manipulacja kolejnością kart na mobile

### DIFF
--- a/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
@@ -56,24 +56,9 @@ class MiniCardView extends React.Component {
                             user={this.props.user} cardIndexInDeck={this.state.cardIndexInDeck}
                             level={this.props.cardLevel} animationDuration={this.props.animationDuration}
                             onClick={() => this.props.changeCardsOrder()}>
-                {
-                    this.props.enemy ?
-                        <>
-                            <IconContainer enemy>
-                                <Icon src={this.props.cardImage ? this.props.cardImage : iconPlaceholder} />
-                            </IconContainer>
-                        </>
-                        : ''
-                }
-                {
-                    this.props.user ?
-                        <>
-                            <IconContainer>
-                                <Icon src={this.props.cardImage ? this.props.cardImage : iconPlaceholder} />
-                            </IconContainer>
-                        </>
-                        : ''
-                }
+                <IconContainer enemy={this.props.enemy}>
+                    <Icon src={this.props.cardImage ? this.props.cardImage : iconPlaceholder} />
+                </IconContainer>
             </CardsContainer>
         );
     }

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
@@ -14,6 +14,8 @@ class MiniCardView extends React.Component {
         cardLevel -> information about card level
         visible -> handle visibility of card
         cardImage -> card icon
+        cardsOrder -> to show particular card in BattleView and hide the rest
+        setOpacity -> to handle opacity animation in BattleView
      */
 
     state = {
@@ -22,6 +24,7 @@ class MiniCardView extends React.Component {
     }
 
     showNewCardsOrder = () => {
+        // shows new ordered cards
         setTimeout(() => {
             this.setState({
                 miniCardOpacity: '1'
@@ -30,7 +33,9 @@ class MiniCardView extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if(prevProps.cardsOrder && (prevProps.cardsOrder !== this.props.cardsOrder)) {
+        // fade animation, and update orders, when cardsOrder did change
+        if(prevProps.cardsOrder &&
+            (prevProps.cardsOrder !== this.props.cardsOrder)) {
             this.setState({
                miniCardOpacity: '0'
             });

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
@@ -19,9 +19,10 @@ class MiniCardView extends React.Component {
         return (
             <CardsContainer visible={this.props.visible} setTranslateX={this.props.setTranslateX}
                             enemy={this.props.enemy} user={this.props.user}
-                            onClick={() => this.props.cardsOrderManipulate(this.props.initCardsOrder)}
-                            level={this.props.cardLevel} animationDuration={this.props.animationDuration}
-                            initCardsOrder={this.props.initCardsOrder}>
+                            onClick={() =>
+                                this.props.userCardsOrderManipulate(this.props.cardsOrder,
+                                    this.props.cardsOrder + 1)}
+                            level={this.props.cardLevel} animationDuration={this.props.animationDuration}>
                 {
                     this.props.enemy ?
                         <>

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
@@ -20,7 +20,7 @@ class MiniCardView extends React.Component {
 
     state = {
         miniCardOpacity: '1',
-        cardsOrder: this.props.cardsOrder,
+        cardIndexInDeck: this.props.cardIndexInDeck,
     }
 
     showNewCardsOrder = () => {
@@ -34,16 +34,16 @@ class MiniCardView extends React.Component {
 
     componentDidUpdate(prevProps) {
         // fade animation, and update orders, when cardsOrder did change
-        if(prevProps.cardsOrder &&
-            (prevProps.cardsOrder !== this.props.cardsOrder)) {
+        if(prevProps.cardIndexInDeck &&
+            (prevProps.cardIndexInDeck !== this.props.cardIndexInDeck)) {
             this.setState({
                miniCardOpacity: '0'
             });
 
             setTimeout(() => {
-                let newCardsOrder = this.props.cardsOrder;
+                let newCardIndexInDeck = this.props.cardIndexInDeck;
                 this.setState({
-                    cardsOrder: newCardsOrder
+                    cardIndexInDeck: newCardIndexInDeck
                 }, this.showNewCardsOrder);
             }, secondStepAnimationDuration);
         }
@@ -53,7 +53,7 @@ class MiniCardView extends React.Component {
         return (
             <CardsContainer visible={this.props.visible} setTranslateX={this.props.setTranslateX}
                             setOpacity={this.state.miniCardOpacity} enemy={this.props.enemy}
-                            user={this.props.user} cardsOrder={this.state.cardsOrder}
+                            user={this.props.user} cardIndexInDeck={this.state.cardIndexInDeck}
                             level={this.props.cardLevel} animationDuration={this.props.animationDuration}
                             onClick={() => this.props.changeCardsOrder()}>
                 {

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
@@ -3,6 +3,7 @@ import CardsContainer from "./styled-components/CardsContainer";
 import Icon from "./styled-components/Icon";
 import iconPlaceholder from '../../../../../assets/icons/upload_image_dark.svg';
 import IconContainer from "./styled-components/IconContainer";
+import {secondStepAnimationDuration} from "../../../../utils/globals";
 
 class MiniCardView extends React.Component {
     /*
@@ -15,11 +16,39 @@ class MiniCardView extends React.Component {
         cardImage -> card icon
      */
 
+    state = {
+        miniCardOpacity: '1',
+        cardsOrder: 0,
+    }
+
+    componentDidUpdate(prevProps) {
+        if(prevProps.cardsOrder && (prevProps.cardsOrder !== this.props.cardsOrder)) {
+            this.setState({
+               miniCardOpacity: '0'
+            });
+
+            setTimeout(() => {
+                let newCardsOrder = this.props.cardsOrder;
+                this.setState({
+                    cardsOrder: newCardsOrder
+                });
+            }, secondStepAnimationDuration);
+
+            setTimeout(() => {
+                this.setState({
+                    miniCardOpacity: '1'
+                });
+            }, secondStepAnimationDuration + 100);
+        }
+    }
+
     render() {
         return (
             <CardsContainer visible={this.props.visible} setTranslateX={this.props.setTranslateX}
-                            enemy={this.props.enemy} user={this.props.user}
-                            level={this.props.cardLevel} animationDuration={this.props.animationDuration}>
+                            setOpacity={this.state.miniCardOpacity} enemy={this.props.enemy}
+                            user={this.props.user} cardsOrder={this.state.cardsOrder}
+                            level={this.props.cardLevel} animationDuration={this.props.animationDuration}
+                            onClick={() => this.props.changeCardsOrder()}>
                 {
                     this.props.enemy ?
                         <>

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
@@ -21,6 +21,14 @@ class MiniCardView extends React.Component {
         cardsOrder: this.props.cardsOrder,
     }
 
+    showNewCardsOrder = () => {
+        setTimeout(() => {
+            this.setState({
+                miniCardOpacity: '1'
+            });
+        }, 100)
+    }
+
     componentDidUpdate(prevProps) {
         if(prevProps.cardsOrder && (prevProps.cardsOrder !== this.props.cardsOrder)) {
             this.setState({
@@ -31,14 +39,8 @@ class MiniCardView extends React.Component {
                 let newCardsOrder = this.props.cardsOrder;
                 this.setState({
                     cardsOrder: newCardsOrder
-                });
+                }, this.showNewCardsOrder);
             }, secondStepAnimationDuration);
-
-            setTimeout(() => {
-                this.setState({
-                    miniCardOpacity: '1'
-                });
-            }, secondStepAnimationDuration + 100);
         }
     }
 

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
@@ -18,7 +18,7 @@ class MiniCardView extends React.Component {
 
     state = {
         miniCardOpacity: '1',
-        cardsOrder: 0,
+        cardsOrder: this.props.cardsOrder,
     }
 
     componentDidUpdate(prevProps) {

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
@@ -19,9 +19,6 @@ class MiniCardView extends React.Component {
         return (
             <CardsContainer visible={this.props.visible} setTranslateX={this.props.setTranslateX}
                             enemy={this.props.enemy} user={this.props.user}
-                            onClick={() =>
-                                this.props.userCardsOrderManipulate(this.props.cardsOrder,
-                                    this.props.cardsOrder + 1)}
                             level={this.props.cardLevel} animationDuration={this.props.animationDuration}>
                 {
                     this.props.enemy ?

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/MiniCardView.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Container from "./styled-components/Container";
+import CardsContainer from "./styled-components/CardsContainer";
 import Icon from "./styled-components/Icon";
 import iconPlaceholder from '../../../../../assets/icons/upload_image_dark.svg';
 import IconContainer from "./styled-components/IconContainer";
@@ -17,9 +17,11 @@ class MiniCardView extends React.Component {
 
     render() {
         return (
-            <Container visible={this.props.visible} setTranslateX={this.props.setTranslateX}
-                       enemy={this.props.enemy} user={this.props.user} level={this.props.cardLevel}
-                       animationDuration={this.props.animationDuration}>
+            <CardsContainer visible={this.props.visible} setTranslateX={this.props.setTranslateX}
+                            enemy={this.props.enemy} user={this.props.user}
+                            onClick={() => this.props.cardsOrderManipulate(this.props.initCardsOrder)}
+                            level={this.props.cardLevel} animationDuration={this.props.animationDuration}
+                            initCardsOrder={this.props.initCardsOrder}>
                 {
                     this.props.enemy ?
                         <>
@@ -38,7 +40,7 @@ class MiniCardView extends React.Component {
                         </>
                         : ''
                 }
-            </Container>
+            </CardsContainer>
         );
     }
 }

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/styled-components/CardsContainer.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/styled-components/CardsContainer.js
@@ -10,7 +10,7 @@ function handleColor(level, theme) {
     else return theme.colors.greenyBluey;
 }
 
-const Container = styled.div`
+const CardsContainer = styled.div`
   border-top-left-radius: ${({user}) => user ? '16px' : '0'};
   border-top-right-radius: ${({user}) => user ? '16px' : '0'};
   border-bottom-left-radius: ${({enemy}) => enemy ? '16px' : '0'};
@@ -20,10 +20,9 @@ const Container = styled.div`
   height: 64px;
   display: ${({visible}) => visible ? 'flex' : 'none'};
   flex-direction: column;
-  align-items: center;
   justify-content: flex-end;
   transition: transform ${({animationDuration}) => animationDuration ? animationDuration : '0.5'}s ease-in-out;
   transform: translateX(${({setTranslateX}) => setTranslateX ? setTranslateX : '0'});
 `;
 
-export default Container;
+export default CardsContainer;

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/styled-components/CardsContainer.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/styled-components/CardsContainer.js
@@ -18,10 +18,10 @@ const CardsContainer = styled.div`
   background-color: ${({level, theme}) => handleColor(level, theme)};
   width: 54px;
   height: 64px;
-  display: ${({cardsOrder}) => (cardsOrder === 1) ? 'none' : 'flex'};
+  display: ${({cardIndexInDeck}) => (cardIndexInDeck === 1) ? 'none' : 'flex'};
   flex-direction: column;
   justify-content: flex-end;
-  order: ${({cardsOrder}) => cardsOrder};
+  order: ${({cardIndexInDeck}) => cardIndexInDeck};
   transition: transform ${({animationDuration}) => animationDuration ? animationDuration : '0.5'}s, opacity 0.5s ease-in-out;
   transform: translateX(${({setTranslateX}) => setTranslateX ? setTranslateX : '0'});
   opacity: ${({setOpacity}) => setOpacity ? setOpacity : '1'};

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/styled-components/CardsContainer.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/styled-components/CardsContainer.js
@@ -18,7 +18,7 @@ const CardsContainer = styled.div`
   background-color: ${({level, theme}) => handleColor(level, theme)};
   width: 54px;
   height: 64px;
-  display: ${({visible}) => visible ? 'flex' : 'none'};
+  display: ${({cardsOrder}) => (cardsOrder === 1) ? 'none' : 'flex'};
   flex-direction: column;
   justify-content: flex-end;
   order: ${({cardsOrder}) => cardsOrder};

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/styled-components/CardsContainer.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/MiniCardView/styled-components/CardsContainer.js
@@ -21,8 +21,10 @@ const CardsContainer = styled.div`
   display: ${({visible}) => visible ? 'flex' : 'none'};
   flex-direction: column;
   justify-content: flex-end;
-  transition: transform ${({animationDuration}) => animationDuration ? animationDuration : '0.5'}s ease-in-out;
+  order: ${({cardsOrder}) => cardsOrder};
+  transition: transform ${({animationDuration}) => animationDuration ? animationDuration : '0.5'}s, opacity 0.5s ease-in-out;
   transform: translateX(${({setTranslateX}) => setTranslateX ? setTranslateX : '0'});
+  opacity: ${({setOpacity}) => setOpacity ? setOpacity : '1'};
 `;
 
 export default CardsContainer;

--- a/WMIAdventure/frontend/src/js/components/battle/molecules/EnemyStateContainer/styled-components/Container.js
+++ b/WMIAdventure/frontend/src/js/components/battle/molecules/EnemyStateContainer/styled-components/Container.js
@@ -4,10 +4,8 @@ const Container = styled.div`
   border-top-left-radius: 16px;
   border-top-right-radius: 16px;
   background-color: ${({theme}) => theme.colors.light2};
-  min-width: 226px;
+  width: 228px;
   height: 136px;
-  width: 60%;
-  max-width: 380px;
   
   transition: transform 0.5s ease-in-out;
   transform: translateX(${({setTranslateX}) => setTranslateX ? setTranslateX : '0'});

--- a/WMIAdventure/frontend/src/js/components/battle/molecules/UserStateContainer/styled-components/Container.js
+++ b/WMIAdventure/frontend/src/js/components/battle/molecules/UserStateContainer/styled-components/Container.js
@@ -4,10 +4,8 @@ const Container = styled.div`
   border-bottom-left-radius: 16px;
   border-bottom-right-radius: 16px;
   background-color: ${({theme}) => theme.colors.light2};
-  min-width: 226px;
+  width: 228px;
   height: 136px;
-  width: 60%;
-  max-width: 380px;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -46,7 +46,8 @@ class BattleView extends React.Component {
         // prototype data
         cardLevels : [3, 3, 2, 1, 1],
         icons : [icon1, icon2, icon3, icon4, icon5],
-        cardsUserOrder : [1, 2, 3, 4, 5],
+        // states to handle cards orders, pass to CompactCardView and MiniCardView as props
+        cardsUserOrder : [1, 2, 3, 4, 5], // this means: first card on first place and so on
         cardsEnemyOrder : [1, 2, 3, 4, 5],
     }
 
@@ -105,40 +106,20 @@ class BattleView extends React.Component {
             + secondStepAnimationDuration * 2 + 100);
     }
 
-    enemyCompactOpacityAnimation = () => {
-        this.setState({
-           enemyCompactCardOpacity: '0'
-        });
-
-        setTimeout(() => {
-            this.setState({
-                enemyCompactCardOpacity: '1'
-            });
-        }, secondStepAnimationDuration*2);
-    }
-
-    userCompactOpacityAnimation = () => {
-        this.setState({
-            userCompactCardOpacity: '0'
-        });
-
-        setTimeout(() => {
-            this.setState({
-                userCompactCardOpacity: '1'
-            });
-        }, secondStepAnimationDuration*2);
-    }
-
+    // prototype function, runs if we click on mini enemy cards
     changeCardsEnemyOrder = () => {
         this.setState({
             cardsEnemyOrder: [3, 2, 1, 5, 4]
-        }, this.enemyCompactOpacityAnimation);
+            // this means: third card on first place, second on second, first on third and so on
+        });
     }
 
+    // prototype function, runs if we click on mini user cards
     changeCardsUserOrder = () => {
         this.setState({
             cardsUserOrder: [5, 4, 2, 3, 1]
-        }, this.userCompactOpacityAnimation);
+            // this means: fifth card on first place, fourth on second, second on third and so on
+        });
     }
 
     render() {
@@ -154,7 +135,8 @@ class BattleView extends React.Component {
                                     <EnemyStateContainer setTranslateX={this.state.enemyStateContainerTranslateX}
                                                          hp={this.state.enemyHp} shield={this.state.enemyShield} />
                                     <FlexGapContainer setWidth={'100%'} gap={'4px'} reverse>
-                                        {/* first card is not visible because is the same as Compact card */}
+                                        {/* Enemy MiniCards!
+                                        First card is not visible because is the same as Compact card */}
                                         {[...Array(5)].map(
                                             (e,i) => {
                                                 return (
@@ -170,6 +152,7 @@ class BattleView extends React.Component {
                                         )}
                                     </FlexGapContainer>
                                 </ColumnGapContainer>
+                                {/* Enemy Compact Card! Particular Compact Card is visible if order === 1 */}
                                 {[...Array(5)].map(
                                     (e,i) => {
                                         return (
@@ -185,6 +168,7 @@ class BattleView extends React.Component {
                             </FlexGapContainer>
                             <KuceInBattle visible={this.state.kuceInBattleVisible} />
                             <FlexGapContainer setMargin={'0 0 10px 0'}>
+                                {/* User Compact Card! Particular Compact Card is visible if order === 1 */}
                                 {[...Array(5)].map(
                                     (e,i) => {
                                         return (
@@ -199,7 +183,8 @@ class BattleView extends React.Component {
                                 )}
                                 <ColumnGapContainer gap={'0'}>
                                     <FlexGapContainer setWidth={'100%'} gap={'4px'}>
-                                        {/* first card is not visible because is the same as Compact card */}
+                                        {/* User MiniCards!
+                                        First card is not visible because is the same as Compact card */}
                                         {[...Array(5)].map(
                                             (e,i) => {
                                                 return (

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -52,8 +52,8 @@ class BattleView extends React.Component {
         // prototype data
         cardLevels : [3, 3, 2, 1, 1],
         icons : [icon1, icon2, icon3, icon4, icon5],
-        initCardsOrder : [1, 2, 3, 4, 5],
-        orderPlaceDistance: '58px',
+        cardsOrder : [1, 2, 3, 4, 5],
+        orderPlaceDistance: 58,
     }
 
     componentDidUpdate(prevProps) {
@@ -119,15 +119,35 @@ class BattleView extends React.Component {
         + secondStepAnimationDuration * 3);
     }
 
+    updateCardsOrder = (cardInitOrder, orderToSet) => {
+        let newCardsOrder = this.state.cardsOrder.slice();
+
+        let savePosValue = newCardsOrder[cardInitOrder - 1];
+        newCardsOrder[cardInitOrder - 1] = orderToSet - 1;
+        newCardsOrder[orderToSet - 1] = savePosValue;
+    }
+
     userCardsOrderManipulate = (cardInitOrder, orderToSet) => {
         console.log(cardInitOrder);
         console.log(orderToSet);
 
-        //...
+        let newUserMiniCardsTranslateX = this.state.userMiniCardsTranslateX.slice();
+        newUserMiniCardsTranslateX[cardInitOrder - 1] =
+            `${this.state.orderPlaceDistance * (orderToSet - cardInitOrder)}px`;
+
+        for(let i = 0; i < Math.abs(cardInitOrder - orderToSet); i++) {
+            newUserMiniCardsTranslateX[orderToSet - i - 1] =
+                `${this.state.orderPlaceDistance * (-1)}px`;
+        }
+
+        this.setState({
+            userMiniCardsTranslateX: newUserMiniCardsTranslateX,
+        });
 
         // card(cardInitOrder) set translateX placeDistance * (orderToSet - cardInitOrder)
         // for let i=0; i < (absolute(cardInitOrder-orderToSet) - 1); i++ do
             // card(orderToSet - i) -> set translateX placeDistance * (-1)
+        // update cardsOrder
     }
 
     enemyCardsOrderManipulate = (cardInitOrder, orderToSet) => {
@@ -154,7 +174,7 @@ class BattleView extends React.Component {
                                                 return (
                                                     <MiniCardView key={`enemyCard-${i}`}
                                                                   enemyCardsOrderManipulate={this.enemyCardsOrderManipulate}
-                                                                  initCardsOrder={this.state.initCardsOrder[5 - i]}
+                                                                  cardsOrder={this.state.cardsOrder[5 - i]}
                                                                   battleStarted={this.state.battleStarted}
                                                                   setTranslateX={this.state.enemyMiniCardsTranslateX}
                                                                   enemy cardLevel={this.state.cardLevels[i]}
@@ -184,7 +204,7 @@ class BattleView extends React.Component {
                                                 return (
                                                     <MiniCardView key={`userCard-${i}`}
                                                                   userCardsOrderManipulate={this.userCardsOrderManipulate}
-                                                                  initCardsOrder={this.state.initCardsOrder[i]}
+                                                                  cardsOrder={this.state.cardsOrder[i]}
                                                                   battleStarted={this.state.battleStarted}
                                                                   setTranslateX={this.state.userMiniCardsTranslateX[i]}
                                                                   user cardLevel={this.state.cardLevels[i]}

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -43,10 +43,6 @@ class BattleView extends React.Component {
         enemyShield: '0',
         userShield: '0',
 
-        // opacity of compact card view elements
-        enemyCompactCardOpacity: '1',
-        userCompactCardOpacity: '1',
-
         // prototype data
         cardLevels : [3, 3, 2, 1, 1],
         icons : [icon1, icon2, icon3, icon4, icon5],
@@ -178,7 +174,6 @@ class BattleView extends React.Component {
                                     (e,i) => {
                                         return (
                                             <CompactCardView key={`enemyCompactCard-${i}`}
-                                                             setOpacity={this.state.enemyCompactCardOpacity}
                                                              cardsOrder={this.state.cardsEnemyOrder[i]}
                                                              cardImage={this.state.icons[i]} cardName={'Karta 1'}
                                                              setWidth={'124px'} cardLevel={3} setHeight={'200px'}
@@ -195,7 +190,6 @@ class BattleView extends React.Component {
                                         return (
                                             <CompactCardView key={`userCompactCard-${i}`}
                                                              cardsOrder={this.state.cardsUserOrder[i]}
-                                                             setOpacity={this.state.userCompactCardOpacity}
                                                              cardImage={this.state.icons[i]} cardName={'Karta 1'}
                                                              setWidth={'124px'} cardLevel={2} setHeight={'200px'}
                                                              setTranslateX={this.state.userCompactCardTranslateX}

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -43,18 +43,15 @@ class BattleView extends React.Component {
         enemyShield: '0',
         userShield: '0',
 
-        // access cards animation during battle
-        battleStarted: false,
-
-        // set translate X to specific card
-        // ... maybe arrays?
+        // opacity of compact card view elements
+        enemyCompactCardOpacity: '1',
+        userCompactCardOpacity: '1',
 
         // prototype data
         cardLevels : [3, 3, 2, 1, 1],
         icons : [icon1, icon2, icon3, icon4, icon5],
         cardsUserOrder : [1, 2, 3, 4, 5],
         cardsEnemyOrder : [1, 2, 3, 4, 5],
-        orderPlaceDistance: 58,
     }
 
     componentDidUpdate(prevProps) {
@@ -110,26 +107,42 @@ class BattleView extends React.Component {
             });
         }, battleInitLoadingDuration
             + secondStepAnimationDuration * 2 + 100);
+    }
 
-        // Give access to animations during battle
+    enemyCompactOpacityAnimation = () => {
+        this.setState({
+           enemyCompactCardOpacity: '0'
+        });
+
         setTimeout(() => {
             this.setState({
-                battleStarted: true,
+                enemyCompactCardOpacity: '1'
             });
-        },battleInitLoadingDuration
-        + secondStepAnimationDuration * 3);
+        }, secondStepAnimationDuration*2);
+    }
+
+    userCompactOpacityAnimation = () => {
+        this.setState({
+            userCompactCardOpacity: '0'
+        });
+
+        setTimeout(() => {
+            this.setState({
+                userCompactCardOpacity: '1'
+            });
+        }, secondStepAnimationDuration*2);
     }
 
     changeCardsEnemyOrder = () => {
         this.setState({
             cardsEnemyOrder: [3, 2, 1, 5, 4]
-        });
+        }, this.enemyCompactOpacityAnimation);
     }
 
     changeCardsUserOrder = () => {
         this.setState({
             cardsUserOrder: [5, 4, 2, 3, 1]
-        });
+        }, this.userCompactOpacityAnimation);
     }
 
     render() {
@@ -152,7 +165,6 @@ class BattleView extends React.Component {
                                                     <MiniCardView key={`enemyCard-${i}`}
                                                                   changeCardsOrder={this.changeCardsEnemyOrder}
                                                                   cardsOrder={this.state.cardsEnemyOrder[i]}
-                                                                  battleStarted={this.state.battleStarted}
                                                                   setTranslateX={this.state.enemyMiniCardsTranslateX}
                                                                   enemy cardLevel={this.state.cardLevels[i]}
                                                                   animationDuration={`0.${9 - i}`}
@@ -162,17 +174,35 @@ class BattleView extends React.Component {
                                         )}
                                     </FlexGapContainer>
                                 </ColumnGapContainer>
-                                <CompactCardView cardImage={icon1} cardName={'Karta 1'}
-                                                 setWidth={'124px'} cardLevel={3} setHeight={'200px'}
-                                                 setTranslateX={this.state.enemyCompactCardTranslateX}
-                                                 setMargin={'0 0 0 10px'} />
+                                {[...Array(5)].map(
+                                    (e,i) => {
+                                        return (
+                                            <CompactCardView key={`enemyCompactCard-${i}`}
+                                                             setOpacity={this.state.enemyCompactCardOpacity}
+                                                             cardsOrder={this.state.cardsEnemyOrder[i]}
+                                                             cardImage={this.state.icons[i]} cardName={'Karta 1'}
+                                                             setWidth={'124px'} cardLevel={3} setHeight={'200px'}
+                                                             setTranslateX={this.state.enemyCompactCardTranslateX}
+                                                             setMargin={'0 0 0 10px'} />
+                                        );
+                                    }
+                                )}
                             </FlexGapContainer>
                             <KuceInBattle visible={this.state.kuceInBattleVisible} />
                             <FlexGapContainer setMargin={'0 0 10px 0'}>
-                                <CompactCardView cardImage={icon1} cardName={'Karta 1'}
-                                                 setWidth={'124px'} cardLevel={1} setHeight={'200px'}
-                                                 setTranslateX={this.state.userCompactCardTranslateX}
-                                                 setMargin={'0 10px 0 0'} />
+                                {[...Array(5)].map(
+                                    (e,i) => {
+                                        return (
+                                            <CompactCardView key={`userCompactCard-${i}`}
+                                                             cardsOrder={this.state.cardsUserOrder[i]}
+                                                             setOpacity={this.state.userCompactCardOpacity}
+                                                             cardImage={this.state.icons[i]} cardName={'Karta 1'}
+                                                             setWidth={'124px'} cardLevel={2} setHeight={'200px'}
+                                                             setTranslateX={this.state.userCompactCardTranslateX}
+                                                             setMargin={'0 10px 0 0'} />
+                                        );
+                                    }
+                                )}
                                 <ColumnGapContainer gap={'0'}>
                                     <FlexGapContainer setWidth={'100%'} gap={'4px'}>
                                         {/* first card is not visible because is the same as Compact card */}
@@ -182,7 +212,6 @@ class BattleView extends React.Component {
                                                     <MiniCardView key={`userCard-${i}`}
                                                                   changeCardsOrder={this.changeCardsUserOrder}
                                                                   cardsOrder={this.state.cardsUserOrder[i]}
-                                                                  battleStarted={this.state.battleStarted}
                                                                   setTranslateX={this.state.userMiniCardsTranslateX[i]}
                                                                   user cardLevel={this.state.cardLevels[i]}
                                                                   animationDuration={`0.${9 - i}`}

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -52,7 +52,8 @@ class BattleView extends React.Component {
         // prototype data
         cardLevels : [3, 3, 2, 1, 1],
         icons : [icon1, icon2, icon3, icon4, icon5],
-        cardsOrder : [1, 2, 3, 4, 5],
+        cardsUserOrder : [1, 2, 3, 4, 5],
+        cardsEnemyOrder : [1, 2, 3, 4, 5],
         orderPlaceDistance: 58,
     }
 
@@ -119,10 +120,16 @@ class BattleView extends React.Component {
         + secondStepAnimationDuration * 3);
     }
 
-    changeCardsOrder = () => {
+    changeCardsEnemyOrder = () => {
         this.setState({
-            cardsOrder: [5, 4, 2, 3, 1]
-        })
+            cardsEnemyOrder: [3, 2, 1, 5, 4]
+        });
+    }
+
+    changeCardsUserOrder = () => {
+        this.setState({
+            cardsUserOrder: [5, 4, 2, 3, 1]
+        });
     }
 
     render() {
@@ -137,18 +144,19 @@ class BattleView extends React.Component {
                                 <ColumnGapContainer gap={'0'}>
                                     <EnemyStateContainer setTranslateX={this.state.enemyStateContainerTranslateX}
                                                          hp={this.state.enemyHp} shield={this.state.enemyShield} />
-                                    <FlexGapContainer setWidth={'100%'} gap={'4px'}>
+                                    <FlexGapContainer setWidth={'100%'} gap={'4px'} reverse>
                                         {/* first card is not visible because is the same as Compact card */}
                                         {[...Array(5)].map(
                                             (e,i) => {
                                                 return (
                                                     <MiniCardView key={`enemyCard-${i}`}
-                                                                  cardsOrder={this.state.cardsOrder[5 - i]}
+                                                                  changeCardsOrder={this.changeCardsEnemyOrder}
+                                                                  cardsOrder={this.state.cardsEnemyOrder[i]}
                                                                   battleStarted={this.state.battleStarted}
                                                                   setTranslateX={this.state.enemyMiniCardsTranslateX}
                                                                   enemy cardLevel={this.state.cardLevels[i]}
-                                                                  visible={!(i===0)} animationDuration={`0.${10 - i}`}
-                                                                  cardImage={this.state.icons[5 - i]}/>
+                                                                  animationDuration={`0.${9 - i}`}
+                                                                  cardImage={this.state.icons[i]}/>
                                                 );
                                             }
                                         )}
@@ -172,12 +180,12 @@ class BattleView extends React.Component {
                                             (e,i) => {
                                                 return (
                                                     <MiniCardView key={`userCard-${i}`}
-                                                                  changeCardsOrder={this.changeCardsOrder}
-                                                                  cardsOrder={this.state.cardsOrder[i]}
+                                                                  changeCardsOrder={this.changeCardsUserOrder}
+                                                                  cardsOrder={this.state.cardsUserOrder[i]}
                                                                   battleStarted={this.state.battleStarted}
                                                                   setTranslateX={this.state.userMiniCardsTranslateX[i]}
                                                                   user cardLevel={this.state.cardLevels[i]}
-                                                                  visible={!(i===0)} animationDuration={`0.${10 - i}`}
+                                                                  animationDuration={`0.${9 - i}`}
                                                                   cardImage={this.state.icons[i]}/>
                                                 );
                                             }

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -119,41 +119,20 @@ class BattleView extends React.Component {
         + secondStepAnimationDuration * 3);
     }
 
-    updateCardsOrder = (cardInitOrder, orderToSet) => {
-        let newCardsOrder = this.state.cardsOrder.slice();
+   // userCardsOrderUpdate(cardsPositions) {
+        // cardsPositions = [1, 2, 3, 4, 5]; // => [0, 0, 0, 0, 0]
+        // pierwsza karta na pierwszym miejscu, druga na drugim itd.
 
-        let savePosValue = newCardsOrder[cardInitOrder - 1];
-        newCardsOrder[cardInitOrder - 1] = orderToSet - 1;
-        newCardsOrder[orderToSet - 1] = savePosValue;
-    }
+        // cardsPositions = [2, 4, 5, 1, 3]; // => [2*58, 0, 2*58, -2*58, -2*58]
+        // druga karta na pierwszym, czwarta na drugim, piąta na trzecim itd.
+        // albo inaczej pierwsza karta na czwartym, druga na pierwszym, trzecia na piątym itd.
 
-    userCardsOrderManipulate = (cardInitOrder, orderToSet) => {
-        console.log(cardInitOrder);
-        console.log(orderToSet);
-
-        let newUserMiniCardsTranslateX = this.state.userMiniCardsTranslateX.slice();
-        newUserMiniCardsTranslateX[cardInitOrder - 1] =
-            `${this.state.orderPlaceDistance * (orderToSet - cardInitOrder)}px`;
-
-        for(let i = 0; i < Math.abs(cardInitOrder - orderToSet); i++) {
-            newUserMiniCardsTranslateX[orderToSet - i - 1] =
-                `${this.state.orderPlaceDistance * (-1)}px`;
-        }
-
-        this.setState({
-            userMiniCardsTranslateX: newUserMiniCardsTranslateX,
-        });
-
-        // card(cardInitOrder) set translateX placeDistance * (orderToSet - cardInitOrder)
-        // for let i=0; i < (absolute(cardInitOrder-orderToSet) - 1); i++ do
-            // card(orderToSet - i) -> set translateX placeDistance * (-1)
-        // update cardsOrder
-    }
-
-    enemyCardsOrderManipulate = (cardInitOrder, orderToSet) => {
-        console.log(cardInitOrder);
-        console.log(orderToSet);
-    }
+        // jedynka moze sie przesuwac 58, 2*58, 3*58
+        // dwójka moze sie przesuwac 58, 2*58, 3*58
+        // trójka moze sie przesuwac -58, 58, 2*58
+        // czwórka moze sie przesuwac -2*58, -58, 58
+        // piątka moze sie przesuwac -3*58, -2*58, -58
+  //  }
 
     render() {
         return (
@@ -173,7 +152,6 @@ class BattleView extends React.Component {
                                             (e,i) => {
                                                 return (
                                                     <MiniCardView key={`enemyCard-${i}`}
-                                                                  enemyCardsOrderManipulate={this.enemyCardsOrderManipulate}
                                                                   cardsOrder={this.state.cardsOrder[5 - i]}
                                                                   battleStarted={this.state.battleStarted}
                                                                   setTranslateX={this.state.enemyMiniCardsTranslateX}
@@ -203,7 +181,6 @@ class BattleView extends React.Component {
                                             (e,i) => {
                                                 return (
                                                     <MiniCardView key={`userCard-${i}`}
-                                                                  userCardsOrderManipulate={this.userCardsOrderManipulate}
                                                                   cardsOrder={this.state.cardsOrder[i]}
                                                                   battleStarted={this.state.battleStarted}
                                                                   setTranslateX={this.state.userMiniCardsTranslateX[i]}

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -29,11 +29,11 @@ class BattleView extends React.Component {
         // false -> kuce in the middle not visible, true -> visible
         kuceInBattleVisible: false,
 
-        // states for items animation movement
+        // states for items initial animation movement
         enemyCompactCardTranslateX: '-100vw',
         userCompactCardTranslateX: '100vw',
         enemyMiniCardsTranslateX: '-100vw',
-        userMiniCardsTranslateX: '100vw',
+        userMiniCardsTranslateX: ['100vw', '100vw', '100vw', '100vw', '100vw'],
         enemyStateContainerTranslateX: '-100vw',
         userStateContainerTranslateX: '100vw',
 
@@ -43,9 +43,17 @@ class BattleView extends React.Component {
         enemyShield: '0',
         userShield: '0',
 
+        // access cards animation during battle
+        battleStarted: false,
+
+        // set translate X to specific card
+        // ... maybe arrays?
+
         // prototype data
         cardLevels : [3, 3, 2, 1, 1],
         icons : [icon1, icon2, icon3, icon4, icon5],
+        initCardsOrder : [1, 2, 3, 4, 5],
+        orderPlaceDistance: '58px',
     }
 
     componentDidUpdate(prevProps) {
@@ -84,7 +92,6 @@ class BattleView extends React.Component {
             this.setState({
                 enemyCompactCardTranslateX: '0',
                 userCompactCardTranslateX: '0',
-
             });
         }, battleInitLoadingDuration
             + secondStepAnimationDuration * 2);
@@ -94,7 +101,7 @@ class BattleView extends React.Component {
         setTimeout(() => {
             this.setState({
                 enemyMiniCardsTranslateX: '0',
-                userMiniCardsTranslateX: '0',
+                userMiniCardsTranslateX: ['0', '0', '0', '0', '0'],
                 enemyHp: '100',
                 userHp: '100',
                 enemyShield: '20',
@@ -102,6 +109,30 @@ class BattleView extends React.Component {
             });
         }, battleInitLoadingDuration
             + secondStepAnimationDuration * 2 + 100);
+
+        // Give access to animations during battle
+        setTimeout(() => {
+            this.setState({
+                battleStarted: true,
+            });
+        },battleInitLoadingDuration
+        + secondStepAnimationDuration * 3);
+    }
+
+    userCardsOrderManipulate = (cardInitOrder, orderToSet) => {
+        console.log(cardInitOrder);
+        console.log(orderToSet);
+
+        //...
+
+        // card(cardInitOrder) set translateX placeDistance * (orderToSet - cardInitOrder)
+        // for let i=0; i < (absolute(cardInitOrder-orderToSet) - 1); i++ do
+            // card(orderToSet - i) -> set translateX placeDistance * (-1)
+    }
+
+    enemyCardsOrderManipulate = (cardInitOrder, orderToSet) => {
+        console.log(cardInitOrder);
+        console.log(orderToSet);
     }
 
     render() {
@@ -116,12 +147,15 @@ class BattleView extends React.Component {
                                 <ColumnGapContainer gap={'0'}>
                                     <EnemyStateContainer setTranslateX={this.state.enemyStateContainerTranslateX}
                                                          hp={this.state.enemyHp} shield={this.state.enemyShield} />
-                                    <FlexGapContainer setWidth={'100%'} space>
+                                    <FlexGapContainer setWidth={'100%'} gap={'4px'}>
                                         {/* first card is not visible because is the same as Compact card */}
                                         {[...Array(5)].map(
                                             (e,i) => {
                                                 return (
                                                     <MiniCardView key={`enemyCard-${i}`}
+                                                                  enemyCardsOrderManipulate={this.enemyCardsOrderManipulate}
+                                                                  initCardsOrder={this.state.initCardsOrder[5 - i]}
+                                                                  battleStarted={this.state.battleStarted}
                                                                   setTranslateX={this.state.enemyMiniCardsTranslateX}
                                                                   enemy cardLevel={this.state.cardLevels[i]}
                                                                   visible={!(i===0)} animationDuration={`0.${10 - i}`}
@@ -143,13 +177,16 @@ class BattleView extends React.Component {
                                                  setTranslateX={this.state.userCompactCardTranslateX}
                                                  setMargin={'0 10px 0 0'} />
                                 <ColumnGapContainer gap={'0'}>
-                                    <FlexGapContainer setWidth={'100%'} space>
+                                    <FlexGapContainer setWidth={'100%'} gap={'4px'}>
                                         {/* first card is not visible because is the same as Compact card */}
                                         {[...Array(5)].map(
                                             (e,i) => {
                                                 return (
                                                     <MiniCardView key={`userCard-${i}`}
-                                                                  setTranslateX={this.state.userMiniCardsTranslateX}
+                                                                  userCardsOrderManipulate={this.userCardsOrderManipulate}
+                                                                  initCardsOrder={this.state.initCardsOrder[i]}
+                                                                  battleStarted={this.state.battleStarted}
+                                                                  setTranslateX={this.state.userMiniCardsTranslateX[i]}
                                                                   user cardLevel={this.state.cardLevels[i]}
                                                                   visible={!(i===0)} animationDuration={`0.${10 - i}`}
                                                                   cardImage={this.state.icons[i]}/>

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -32,7 +32,7 @@ class BattleView extends React.Component {
         // states for items initial animation movement
         enemyCompactCardTranslateX: '-100vw',
         userCompactCardTranslateX: '100vw',
-        enemyMiniCardsTranslateX: '-100vw',
+        enemyMiniCardsTranslateX: ['-100vw', '-100vw', '-100vw', '-100vw', '-100vw'],
         userMiniCardsTranslateX: ['100vw', '100vw', '100vw', '100vw', '100vw'],
         enemyStateContainerTranslateX: '-100vw',
         userStateContainerTranslateX: '100vw',
@@ -95,7 +95,7 @@ class BattleView extends React.Component {
         and hp and shield points animation */
         setTimeout(() => {
             this.setState({
-                enemyMiniCardsTranslateX: '0',
+                enemyMiniCardsTranslateX: ['0', '0', '0', '0', '0'],
                 userMiniCardsTranslateX: ['0', '0', '0', '0', '0'],
                 enemyHp: '100',
                 userHp: '100',
@@ -122,6 +122,37 @@ class BattleView extends React.Component {
         });
     }
 
+    getMiniCards = (enemy, i) => {
+        return (
+            <MiniCardView key={enemy ? `enemyCard-${i}` : `userCard-${i}`}
+                          changeCardsOrder={
+                              enemy ? this.changeCardsEnemyOrder : this.changeCardsUserOrder
+                          }
+                          cardIndexInDeck={
+                              enemy ? this.state.cardsEnemyOrder[i] : this.state.cardsUserOrder[i]
+                          }
+                          setTranslateX={
+                              enemy ? this.state.enemyMiniCardsTranslateX[i] : this.state.userMiniCardsTranslateX[i]
+                          }
+                          enemy={enemy} user={!enemy}
+                          cardLevel={this.state.cardLevels[i]}
+                          animationDuration={`0.${9 - i}`}
+                          cardImage={this.state.icons[i]}/>
+        );
+    }
+
+    getCompactCards = (enemy, i) => {
+        return (
+            <CompactCardView key={enemy ? `enemyCompactCard-${i}` : `userCompactCard-${i}`}
+                             cardIndexInDeck={enemy ? this.state.cardsEnemyOrder[i] : this.state.cardsUserOrder[i]}
+                             cardImage={this.state.icons[i]} cardName={`Karta ${i+1}`}
+                             setWidth={'124px'} cardLevel={3} setHeight={'200px'}
+                             setTranslateX={enemy ? this.state.enemyCompactCardTranslateX
+                                 : this.state.userCompactCardTranslateX}
+                             setMargin={enemy ? '0 0 0 10px' : '0 10px 0 0'} />
+        );
+    }
+
     render() {
         return (
             <>
@@ -140,13 +171,7 @@ class BattleView extends React.Component {
                                         {[...Array(5)].map(
                                             (e,i) => {
                                                 return (
-                                                    <MiniCardView key={`enemyCard-${i}`}
-                                                                  changeCardsOrder={this.changeCardsEnemyOrder}
-                                                                  cardIndexInDeck={this.state.cardsEnemyOrder[i]}
-                                                                  setTranslateX={this.state.enemyMiniCardsTranslateX}
-                                                                  enemy cardLevel={this.state.cardLevels[i]}
-                                                                  animationDuration={`0.${9 - i}`}
-                                                                  cardImage={this.state.icons[i]}/>
+                                                    this.getMiniCards(true, i)
                                                 );
                                             }
                                         )}
@@ -156,12 +181,7 @@ class BattleView extends React.Component {
                                 {[...Array(5)].map(
                                     (e,i) => {
                                         return (
-                                            <CompactCardView key={`enemyCompactCard-${i}`}
-                                                             cardIndexInDeck={this.state.cardsEnemyOrder[i]}
-                                                             cardImage={this.state.icons[i]} cardName={'Karta 1'}
-                                                             setWidth={'124px'} cardLevel={3} setHeight={'200px'}
-                                                             setTranslateX={this.state.enemyCompactCardTranslateX}
-                                                             setMargin={'0 0 0 10px'} />
+                                            this.getCompactCards(true, i)
                                         );
                                     }
                                 )}
@@ -172,12 +192,7 @@ class BattleView extends React.Component {
                                 {[...Array(5)].map(
                                     (e,i) => {
                                         return (
-                                            <CompactCardView key={`userCompactCard-${i}`}
-                                                             cardIndexInDeck={this.state.cardsUserOrder[i]}
-                                                             cardImage={this.state.icons[i]} cardName={'Karta 1'}
-                                                             setWidth={'124px'} cardLevel={2} setHeight={'200px'}
-                                                             setTranslateX={this.state.userCompactCardTranslateX}
-                                                             setMargin={'0 10px 0 0'} />
+                                            this.getCompactCards(false, i)
                                         );
                                     }
                                 )}
@@ -188,13 +203,7 @@ class BattleView extends React.Component {
                                         {[...Array(5)].map(
                                             (e,i) => {
                                                 return (
-                                                    <MiniCardView key={`userCard-${i}`}
-                                                                  changeCardsOrder={this.changeCardsUserOrder}
-                                                                  cardIndexInDeck={this.state.cardsUserOrder[i]}
-                                                                  setTranslateX={this.state.userMiniCardsTranslateX[i]}
-                                                                  user cardLevel={this.state.cardLevels[i]}
-                                                                  animationDuration={`0.${9 - i}`}
-                                                                  cardImage={this.state.icons[i]}/>
+                                                    this.getMiniCards(false, i)
                                                 );
                                             }
                                         )}

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -110,7 +110,7 @@ class BattleView extends React.Component {
     changeCardsEnemyOrder = () => {
         this.setState({
             cardsEnemyOrder: [3, 2, 1, 5, 4]
-            // this means: third card on first place, second on second, first on third and so on
+            // this means: first card on third place, second on second, third on first and so on
         });
     }
 
@@ -118,7 +118,7 @@ class BattleView extends React.Component {
     changeCardsUserOrder = () => {
         this.setState({
             cardsUserOrder: [5, 4, 2, 3, 1]
-            // this means: fifth card on first place, fourth on second, second on third and so on
+            // this means: first card on fifth place, second on fourth, third on second and so on
         });
     }
 
@@ -142,7 +142,7 @@ class BattleView extends React.Component {
                                                 return (
                                                     <MiniCardView key={`enemyCard-${i}`}
                                                                   changeCardsOrder={this.changeCardsEnemyOrder}
-                                                                  cardsOrder={this.state.cardsEnemyOrder[i]}
+                                                                  cardIndexInDeck={this.state.cardsEnemyOrder[i]}
                                                                   setTranslateX={this.state.enemyMiniCardsTranslateX}
                                                                   enemy cardLevel={this.state.cardLevels[i]}
                                                                   animationDuration={`0.${9 - i}`}
@@ -157,7 +157,7 @@ class BattleView extends React.Component {
                                     (e,i) => {
                                         return (
                                             <CompactCardView key={`enemyCompactCard-${i}`}
-                                                             cardsOrder={this.state.cardsEnemyOrder[i]}
+                                                             cardIndexInDeck={this.state.cardsEnemyOrder[i]}
                                                              cardImage={this.state.icons[i]} cardName={'Karta 1'}
                                                              setWidth={'124px'} cardLevel={3} setHeight={'200px'}
                                                              setTranslateX={this.state.enemyCompactCardTranslateX}
@@ -173,7 +173,7 @@ class BattleView extends React.Component {
                                     (e,i) => {
                                         return (
                                             <CompactCardView key={`userCompactCard-${i}`}
-                                                             cardsOrder={this.state.cardsUserOrder[i]}
+                                                             cardIndexInDeck={this.state.cardsUserOrder[i]}
                                                              cardImage={this.state.icons[i]} cardName={'Karta 1'}
                                                              setWidth={'124px'} cardLevel={2} setHeight={'200px'}
                                                              setTranslateX={this.state.userCompactCardTranslateX}
@@ -190,7 +190,7 @@ class BattleView extends React.Component {
                                                 return (
                                                     <MiniCardView key={`userCard-${i}`}
                                                                   changeCardsOrder={this.changeCardsUserOrder}
-                                                                  cardsOrder={this.state.cardsUserOrder[i]}
+                                                                  cardIndexInDeck={this.state.cardsUserOrder[i]}
                                                                   setTranslateX={this.state.userMiniCardsTranslateX[i]}
                                                                   user cardLevel={this.state.cardLevels[i]}
                                                                   animationDuration={`0.${9 - i}`}

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -119,20 +119,11 @@ class BattleView extends React.Component {
         + secondStepAnimationDuration * 3);
     }
 
-   // userCardsOrderUpdate(cardsPositions) {
-        // cardsPositions = [1, 2, 3, 4, 5]; // => [0, 0, 0, 0, 0]
-        // pierwsza karta na pierwszym miejscu, druga na drugim itd.
-
-        // cardsPositions = [2, 4, 5, 1, 3]; // => [2*58, 0, 2*58, -2*58, -2*58]
-        // druga karta na pierwszym, czwarta na drugim, piąta na trzecim itd.
-        // albo inaczej pierwsza karta na czwartym, druga na pierwszym, trzecia na piątym itd.
-
-        // jedynka moze sie przesuwac 58, 2*58, 3*58
-        // dwójka moze sie przesuwac 58, 2*58, 3*58
-        // trójka moze sie przesuwac -58, 58, 2*58
-        // czwórka moze sie przesuwac -2*58, -58, 58
-        // piątka moze sie przesuwac -3*58, -2*58, -58
-  //  }
+    changeCardsOrder = () => {
+        this.setState({
+            cardsOrder: [5, 4, 2, 3, 1]
+        })
+    }
 
     render() {
         return (
@@ -181,6 +172,7 @@ class BattleView extends React.Component {
                                             (e,i) => {
                                                 return (
                                                     <MiniCardView key={`userCard-${i}`}
+                                                                  changeCardsOrder={this.changeCardsOrder}
                                                                   cardsOrder={this.state.cardsOrder[i]}
                                                                   battleStarted={this.state.battleStarted}
                                                                   setTranslateX={this.state.userMiniCardsTranslateX[i]}

--- a/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/CompactCardView.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/CompactCardView.js
@@ -27,7 +27,7 @@ class CompactCardView extends React.Component {
         cardLevel: 1,
         cardImage: null,
         compactCardOpacity: '1',
-        cardsOrder: this.props.cardsOrder,
+        cardIndexInDeck: this.props.cardIndexInDeck,
     }
 
     cardNameLengthHandler = (cardNameLength) => {
@@ -66,17 +66,17 @@ class CompactCardView extends React.Component {
     componentDidUpdate(prevProps) {
         if(this.propsChanged(prevProps))
             this.setStateFromProps();
-        else if(prevProps.cardsOrder
-            && (prevProps.cardsOrder !== this.props.cardsOrder)) {
+        else if(prevProps.cardIndexInDeck
+            && (prevProps.cardIndexInDeck !== this.props.cardIndexInDeck)) {
             // fade animation, and update orders, when cardsOrder did change
             this.setState({
                 compactCardOpacity: '0'
             });
 
             setTimeout(() => {
-                let newCardsOrder = this.props.cardsOrder;
+                let newCardIndexInDeck = this.props.cardIndexInDeck;
                 this.setState({
-                    cardsOrder: newCardsOrder
+                    cardIndexInDeck: newCardIndexInDeck
                 }, this.showNewCardsOrder);
             }, secondStepAnimationDuration);
         }
@@ -88,7 +88,7 @@ class CompactCardView extends React.Component {
                  setMargin={this.props.setMargin} level={this.props.cardLevel}
                  setTranslateX={this.props.setTranslateX}
                  decorationHeight={this.props.decorationHeight} shadow={this.props.shadow}
-                 cardsOrder={this.state.cardsOrder} setOpacity={this.state.compactCardOpacity}>
+                 cardIndexInDeck={this.state.cardIndexInDeck} setOpacity={this.state.compactCardOpacity}>
                 <NameContainer>
                     <Name nameLength={this.cardNameLengthHandler(this.state.cardName)}
                           ownFontSize={this.props.ownFontSize}>

--- a/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/CompactCardView.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/CompactCardView.js
@@ -4,6 +4,7 @@ import Name from './styled-components/Name';
 import Img from './styled-components/Img';
 import upload_image_dark from '../../../../../assets/icons/upload_image_dark.svg';
 import NameContainer from './styled-components/NameContainer';
+import {secondStepAnimationDuration} from "../../../../utils/globals";
 
 class CompactCardView extends React.Component {
     /*
@@ -22,7 +23,9 @@ class CompactCardView extends React.Component {
     state = {
         cardName: ' ',
         cardLevel: 1,
-        cardImage: null
+        cardImage: null,
+        compactCardOpacity: '1',
+        cardsOrder: this.props.cardsOrder,
     }
 
     cardNameLengthHandler = (cardNameLength) => {
@@ -49,9 +52,30 @@ class CompactCardView extends React.Component {
         this.setStateFromProps();
     }
 
+    showNewCardsOrder = () => {
+        setTimeout(() => {
+            this.setState({
+                compactCardOpacity: '1'
+            });
+        }, 100);
+    }
+
     componentDidUpdate(prevProps) {
         if(this.propsChanged(prevProps))
             this.setStateFromProps();
+        else if(prevProps.cardsOrder
+            && (prevProps.cardsOrder !== this.props.cardsOrder)) {
+            this.setState({
+                compactCardOpacity: '0'
+            });
+
+            setTimeout(() => {
+                let newCardsOrder = this.props.cardsOrder;
+                this.setState({
+                    cardsOrder: newCardsOrder
+                }, this.showNewCardsOrder);
+            }, secondStepAnimationDuration);
+        }
     }
 
     render() {
@@ -60,7 +84,7 @@ class CompactCardView extends React.Component {
                  setMargin={this.props.setMargin} level={this.props.cardLevel}
                  setTranslateX={this.props.setTranslateX}
                  decorationHeight={this.props.decorationHeight} shadow={this.props.shadow}
-                 cardsOrder={this.props.cardsOrder} setOpacity={this.props.setOpacity}>
+                 cardsOrder={this.state.cardsOrder} setOpacity={this.state.compactCardOpacity}>
                 <NameContainer>
                     <Name nameLength={this.cardNameLengthHandler(this.state.cardName)}
                           ownFontSize={this.props.ownFontSize}>

--- a/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/CompactCardView.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/CompactCardView.js
@@ -18,6 +18,8 @@ class CompactCardView extends React.Component {
         setTranslateX -> handle movement animation
         cardLevel -> information about card level
         cardImage -> card icon
+        cardsOrder -> to show particular card in BattleView and hide the rest
+        setOpacity -> to handle opacity animation in BattleView
      */
 
     state = {
@@ -53,6 +55,7 @@ class CompactCardView extends React.Component {
     }
 
     showNewCardsOrder = () => {
+        // shows new ordered cards
         setTimeout(() => {
             this.setState({
                 compactCardOpacity: '1'
@@ -65,6 +68,7 @@ class CompactCardView extends React.Component {
             this.setStateFromProps();
         else if(prevProps.cardsOrder
             && (prevProps.cardsOrder !== this.props.cardsOrder)) {
+            // fade animation, and update orders, when cardsOrder did change
             this.setState({
                 compactCardOpacity: '0'
             });

--- a/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/CompactCardView.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/CompactCardView.js
@@ -59,7 +59,8 @@ class CompactCardView extends React.Component {
             <Div setWidth={this.props.setWidth} setHeight={this.props.setHeight}
                  setMargin={this.props.setMargin} level={this.props.cardLevel}
                  setTranslateX={this.props.setTranslateX}
-                 decorationHeight={this.props.decorationHeight} shadow={this.props.shadow}>
+                 decorationHeight={this.props.decorationHeight} shadow={this.props.shadow}
+                 cardsOrder={this.props.cardsOrder} setOpacity={this.props.setOpacity}>
                 <NameContainer>
                     <Name nameLength={this.cardNameLengthHandler(this.state.cardName)}
                           ownFontSize={this.props.ownFontSize}>

--- a/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/styled-components/Div.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/styled-components/Div.js
@@ -9,8 +9,16 @@ function colorHandler(level, theme) {
         return theme.colors.purplyPinky;
 }
 
+function visibleHandle(cardsOrder) {
+    if(cardsOrder) {
+        if(cardsOrder === 1)
+            return 'flex';
+        else return 'none';
+    } else return 'flex';
+}
+
 const Div = styled.div`
-  display: flex;
+  display: ${({cardsOrder}) => visibleHandle(cardsOrder)};
   flex-direction: column;
   align-items: center;
   justify-content: space-between;

--- a/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/styled-components/Div.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/styled-components/Div.js
@@ -32,8 +32,8 @@ const Div = styled.div`
   overflow-y: hidden;
   font-family: 'Roboto', sans-serif;
   box-shadow: ${({shadow}) => shadow ? '0 4px 4px rgba(0, 0, 0, 0.1)' : 'nome'};
-  
-  transition: transform 0.5s ease-in-out;
+  transition: transform 0.5s, opacity 0.5s ease-in-out;
+  opacity: ${({setOpacity}) => setOpacity ? setOpacity : '1'};
   transform: translateX(${({setTranslateX}) => setTranslateX ? setTranslateX : '0'});
 
   @media (min-width: ${({theme}) => theme.overMobile}px) {

--- a/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/styled-components/Div.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/styled-components/Div.js
@@ -9,16 +9,16 @@ function colorHandler(level, theme) {
         return theme.colors.purplyPinky;
 }
 
-function visibleHandle(cardsOrder) {
-    if(cardsOrder) {
-        if(cardsOrder === 1)
+function visibleHandle(cardIndexInDeck) {
+    if(cardIndexInDeck) {
+        if(cardIndexInDeck === 1)
             return 'flex';
         else return 'none';
     } else return 'flex';
 }
 
 const Div = styled.div`
-  display: ${({cardsOrder}) => visibleHandle(cardsOrder)};
+  display: ${({cardIndexInDeck}) => visibleHandle(cardIndexInDeck)};
   flex-direction: column;
   align-items: center;
   justify-content: space-between;

--- a/WMIAdventure/frontend/src/js/components/global/molecules/FlexGapContainer/FlexGapContainer.js
+++ b/WMIAdventure/frontend/src/js/components/global/molecules/FlexGapContainer/FlexGapContainer.js
@@ -5,7 +5,7 @@ class FlexGapContainer extends React.Component {
     render() {
         return (
             <Container setMargin={this.props.setMargin} gap={this.props.gap} space={this.props.space}
-                       setWidth={this.props.setWidth} setHeight={this.props.setHeight}>
+                       setWidth={this.props.setWidth} setHeight={this.props.setHeight} reverse={this.props.reverse}>
                 {this.props.children}
             </Container>
         );

--- a/WMIAdventure/frontend/src/js/components/global/molecules/FlexGapContainer/styled-components/Container.js
+++ b/WMIAdventure/frontend/src/js/components/global/molecules/FlexGapContainer/styled-components/Container.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 const Container = styled.div`
   display: flex;
   align-items: center;
+  flex-direction: ${({reverse}) => reverse ? 'row-reverse' : 'row'};
   justify-content: ${({space}) => space ? 'space-between' : 'center'};
   gap: ${({gap}) => gap ? gap : '0'};
   margin: ${({setMargin}) => setMargin ? setMargin : '0'};


### PR DESCRIPTION
* Za kolejność kart odpowiadają stany *cardsUserOrder* i *cardsEnemyOrder* w **BattleView**
* Gdy klikniemy w Mini Cards usera lub enemy to prototypowo zmienia się kolejność kart na taką jaka jest w prototypowych metodach *changeCardsEnemyOrder* i *changeCardsUserOrder*
* Dodawałem coś do **CompactCardView** - z tego co zaobserwowałem to nie zepsułem czegoś w innych miejscach tego komponentu, ale sprawdźcie też

closes #650 
