### PR TITLE
Battle error handling

### DIFF
--- a/WMIAdventure/frontend/src/js/components/battle/organisms/OpponentSelected/OpponentSelected.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/OpponentSelected/OpponentSelected.js
@@ -10,7 +10,7 @@ import battleIcon from '../../../../../assets/images/battleIcon.png';
 import fastIcon from '../../../../../assets/icons/fast.svg';
 import Media from 'react-media';
 import FlexGapContainer from '../../../global/molecules/FlexGapContainer/FlexGapContainer';
-import {desktop, popUpLoadingMinimalDuration, mobile, secondStepAnimationDuration} from '../../../../utils/globals';
+import {desktop, mobile, popUpLoadingMinimalDuration, secondStepAnimationDuration} from '../../../../utils/globals';
 import GridContainer from './styled-components/GridContainer';
 import FlexEndContainer from './styled-components/FlexEndContainer';
 import FlexCenterContainer from './styled-components/FlexCenterContainer';
@@ -21,6 +21,7 @@ import ColumnGapContainer from '../../../global/molecules/ColumnGapContainer';
 import {getCurrentUserDecks, getCurrentUsername} from "../../../../utils/userData";
 import {fightWithUser} from "../../../../api/gateways/BattleAPIGateway";
 import BattleView from "../BattleView";
+import GenericPopup from "../../../global/atoms/GenericPopup";
 
 class OpponentSelected extends React.Component {
 
@@ -35,6 +36,10 @@ class OpponentSelected extends React.Component {
         // states uses for mount battleView
         battleView: false,
         battleViewPos: '-100vh',
+        error: {
+            visible: false,
+            message: '',
+        },
     }
 
     componentDidMount() {
@@ -49,6 +54,61 @@ class OpponentSelected extends React.Component {
             });
     }
 
+    handleBattleErrors = (resp) => {
+        switch (resp.status) {
+            case 401:
+                this.setState({
+                    error: {
+                        visible: true,
+                        message: "Nie jesteś zalogowany!"
+                    }
+                });
+                break;
+            case 404:
+                this.setState({
+                    error: {
+                        visible: true,
+                        message: "Niekompletna talia kart!"
+                    }
+                })
+                break;
+            case 500:
+                this.setState({
+                    error: {
+                        visible: true,
+                        message: "Błąd serwera! Spróbuj ponownie później."
+                    }
+                })
+                break;
+            default:
+                this.setState({
+                    error: {
+                        visible: true,
+                        message: "Nieznany błąd. Spróbuj ponownie później."
+                    }
+                })
+        }
+    }
+
+    errors = () => {
+        const close = (event) => {
+            event.preventDefault();
+            this.setState({
+                error: {
+                    visible: false,
+                    // Transition remembers component's message
+                    message: this.state.error.message
+                }
+            })
+        }
+
+        return (
+            <GenericPopup header={"Błąd!"} text={this.state.error.message} buttonText={"OK"}
+                          show={this.state.error.visible}
+                          onClickHandler={close}/>
+        )
+    }
+
     quickBattleRunHandler = () => {
         this.props.closeUserPreviewHandler();
         this.props.kuceStartFight();
@@ -60,6 +120,9 @@ class OpponentSelected extends React.Component {
                             this.postBattle(data);
                             this.postBattleOpenHandler();
                         })
+                } else {
+                    this.handleBattleErrors(response);
+                    this.props.kuceStopFight();
                 }
             });
     }
@@ -198,7 +261,9 @@ class OpponentSelected extends React.Component {
                                     setTranslateY={this.state.postBattlePos}/>
                         <BattleView battleView={this.state.battleView}
                                     closeHandler={this.battleViewCloseHandler}
-                                    setTranslateY={this.state.battleViewPos} />
+                                    setTranslateY={this.state.battleViewPos}/>
+
+                        {this.errors()}
                     </>
                 </Media>
 
@@ -259,6 +324,7 @@ class OpponentSelected extends React.Component {
                                     opponentDeck={this.state.opponentDeck}
                                     setOpacity={this.state.postBattleOpacity}
                                     setTranslateY={this.state.postBattlePos}/>
+                        {this.errors()}
                     </>
                 </Media>
             </>

--- a/WMIAdventure/frontend/src/js/components/global/atoms/GenericPopup/GenericPopup.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/GenericPopup/GenericPopup.js
@@ -1,0 +1,51 @@
+import React from "react";
+import Header from "../../../card-editor/atoms/AfterSendCard/styled-components/Header";
+import InfoText from "../../../card-editor/atoms/AfterSendCard/styled-components/InfoText";
+import {Transition} from "react-transition-group";
+import FadeInContainer from "../../../card-editor/molecules/SendCardPopup/styled-components/FadeInContainer";
+import CenteringContainer from "../../../card-editor/molecules/SendCardPopup/styled-components/CenteringContainer";
+import PopupContainer from "../../../card-editor/molecules/SendCardPopup/styled-components/PopupContainer";
+import ContentContainer from "../../../card-editor/molecules/SendCardPopup/styled-components/ContentContainer";
+import TransparentBack from "../../../card-editor/molecules/SendCardPopup/styled-components/TransparentBack";
+import ButtonWithIcon from "../../../battle/atoms/ButtonWithIcon";
+import theme from "../../../../utils/theme";
+import xClose from "../../../../../assets/icons/x-close.svg";
+
+export const timeout = {
+    appear: 50,
+    enter: 50,
+    exit: 500
+};
+
+class GenericPopup extends React.Component {
+    render() {
+        return (
+            <Transition in={this.props.show} timeout={timeout}>
+                {state => (
+                    <FadeInContainer transitionState={state}>
+                        <CenteringContainer>
+                            <PopupContainer>
+                                <ContentContainer>
+                                    <Header>{this.props.header}</Header>
+
+                                    <InfoText>{this.props.text}</InfoText>
+
+                                    <ButtonWithIcon handler={this.props.onClickHandler}
+                                                    color={theme.colors.yellowyOrangy} icon={xClose}>
+                                        {this.props.buttonText}
+                                    </ButtonWithIcon>
+                                </ContentContainer>
+                            </PopupContainer>
+                        </CenteringContainer>
+
+                        <TransparentBack onClick={this.props.onClickHandler}>
+                        </TransparentBack>
+                    </FadeInContainer>
+                )}
+            </Transition>
+
+        );
+    }
+}
+
+export default GenericPopup;

--- a/WMIAdventure/frontend/src/js/components/global/atoms/GenericPopup/index.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/GenericPopup/index.js
@@ -1,0 +1,1 @@
+export {default} from './GenericPopup';


### PR DESCRIPTION
Closes #615 
Przy jakimkolwiek błędzie przy szybkiej walce kuce znikają z ekranu i dostajemy popup z komunikatem błędu:
![image](https://user-images.githubusercontent.com/11946540/141643891-a636aa32-314e-49b5-9441-e3fcb6a86e2b.png)

Każdy popup wygląda tak samo, wyróżniłem kilka konkretnych błędów i dodałem im teksty:
- 401: "Nie jesteś zalogowany!"
- 404: "Niekompletna talia kart!"
- 500: "Błąd serwera! Spróbuj ponownie później."
- Pozostałe: "Nieznany błąd. Spróbuj ponownie później."

Jak chcecie wywołać taki błąd to polecam spróbować walczyć nie będąc zalogowanym, albo tworząc usera bez talii kart