### PR TITLE
Stop turn visualisation

### DIFF
--- a/WMIAdventure/frontend/src/js/api/data-models/battle/Battle.js
+++ b/WMIAdventure/frontend/src/js/api/data-models/battle/Battle.js
@@ -35,7 +35,7 @@ export class Battle {
     nextTurn() {
         if (this.currentTurn)
             this.currentTurn.onTurnEnd();
-        
+
         if (this.currentTurnNum >= this.turnsData.length)
             return null;
 

--- a/WMIAdventure/frontend/src/js/api/data-models/battle/Deck.js
+++ b/WMIAdventure/frontend/src/js/api/data-models/battle/Deck.js
@@ -72,6 +72,8 @@ export class Deck {
         if (!executedCardId)
             return;
         const card = this.cards.filter(card => card.id === executedCardId)[0];
+        if (!card)
+            return;
         card.onTurnEnd();
     }
 }

--- a/WMIAdventure/frontend/src/js/api/data-models/battle/EffectIds.js
+++ b/WMIAdventure/frontend/src/js/api/data-models/battle/EffectIds.js
@@ -1,5 +1,25 @@
-export const statusAffectingEffectIds = [1, 2, 6, 13];
-export const buffsEffectIds = [8, 10, 11, 12, 5];
+export const damageEffectId = 1;
+export const shieldEffectId = 2;
+export const healEffectId = 6;
+export const trueDamageEffectId = 13;
+export const statusAffectingEffectIds = [
+    damageEffectId,
+    shieldEffectId,
+    healEffectId,
+    trueDamageEffectId
+];
+
+export const buffExecuteTwoTimesEffectId = 5;
+export const buffNextCardEffectId = 8;
+export const buffNextCardDamageEffectId = 10;
+export const buffNextCardShieldEffectId = 11;
+export const buffNextCardHealEffectId = 12;
+export const buffsEffectIds = [
+    buffNextCardEffectId,
+    buffNextCardDamageEffectId,
+    buffNextCardShieldEffectId,
+    buffNextCardHealEffectId,
+    buffExecuteTwoTimesEffectId];
 export const randomizeDeckEffectId = 3;
 export const stopForOneTurnEffectId = 4;
 export const blockNextCardEffectId = 7;

--- a/WMIAdventure/frontend/src/js/api/data-models/battle/Player.js
+++ b/WMIAdventure/frontend/src/js/api/data-models/battle/Player.js
@@ -16,7 +16,7 @@ export class Player {
     }
 
     onTurnEnd(usedCardId) {
-        if (this.stoppedTurns > 0)
+        if (!usedCardId && this.stoppedTurns > 0)
             this.stoppedTurns--;
         this.deck.onTurnEnd(usedCardId);
     }

--- a/WMIAdventure/frontend/src/js/api/data-models/battle/Turn.js
+++ b/WMIAdventure/frontend/src/js/api/data-models/battle/Turn.js
@@ -18,6 +18,7 @@ export class Turn {
         this.usedEffects = turnData.used_effects;
         this.user = user;
         this.enemy = enemy;
+        this.swapModifiersForPower();
     }
 
     /**
@@ -46,6 +47,17 @@ export class Turn {
 
         applyEffectToTarget(target, effect);
         this.currentlyExecutingEffectIdx++;
+    }
+
+    swapModifiersForPower() {
+        for (let effect of this.usedEffects) {
+            if (effect.power)
+                continue;
+
+            if (effect.buff)
+                effect.power = effect.buff.modifier;
+        }
+        return this.usedEffects;
     }
 
     /**

--- a/WMIAdventure/frontend/src/js/api/data-models/battle/test/Player.test.js
+++ b/WMIAdventure/frontend/src/js/api/data-models/battle/test/Player.test.js
@@ -42,14 +42,25 @@ test('Should not decrement stoppedTurns below zero', () => {
     const player = playerFromData(examplePlayerWithDeck);
     player.stoppedTurns = 2
 
-    player.onTurnEnd(5);
+    player.onTurnEnd(null);
     expect(player.stoppedTurns).toBe(1);
 
-    player.onTurnEnd(5);
+    player.onTurnEnd(null);
     expect(player.stoppedTurns).toBe(0);
 
-    player.onTurnEnd(5);
+    player.onTurnEnd(null);
     expect(player.stoppedTurns).toBe(0);
+})
+
+test('Should not decrement if a card was executed', () => {
+    const player = playerFromData(examplePlayerWithDeck);
+    player.stoppedTurns = 2
+
+    player.onTurnEnd(6);
+    expect(player.stoppedTurns).toBe(2);
+
+    player.onTurnEnd(6);
+    expect(player.stoppedTurns).toBe(2);
 })
 
 test('Should fetch and extra data correctly', async () => {

--- a/WMIAdventure/frontend/src/js/api/data-models/battle/test/Turn.test.js
+++ b/WMIAdventure/frontend/src/js/api/data-models/battle/test/Turn.test.js
@@ -40,6 +40,22 @@ const exampleTurnData = {
     ],
 }
 
+const exampleTurnDataWithBuff = {
+    card_executor: attacker.id,
+    used_card: 3,
+    used_effects: [
+        {
+            id: 8,
+            target_player: attacker.id,
+            buff: {
+                buff_type: null,
+                modifier: 1.1519924929048808
+            },
+            buffed_card: 3
+        },
+    ],
+}
+
 
 test('Should create turn object correctly', () => {
     const user = playerFromData(attacker);
@@ -90,4 +106,11 @@ test('Should consecutive advance calls affect target with multiple effects', () 
     expect(enemy.deck.cards[4].id).toBe(exampleTurnData.used_effects[1].new_deck_order[4]);
 });
 
+test('Should handle buff modifiers as power', () => {
+    const user = playerFromData(attacker);
+    const enemy = playerFromData(defender);
+    const turn = new Turn(exampleTurnDataWithBuff, user, enemy);
+    expect(turn.usedEffects[0].power).toBe(exampleTurnDataWithBuff.used_effects[0].buff.modifier);
+
+});
 

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -440,8 +440,10 @@ class BattleView extends React.Component {
             });
         }, nextStepAnimationDuration);
 
+        const usedEffect = this.state.battle.currentTurn.getNextEffect()
         this.state.battle.currentTurn.advance();
         // TODO: here call function doing particular effect for example damage, change card-order etc.
+        // executeEffect(usedEffect);
     }
 
     callNextEffectIconAction(userTurn, index) {

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -443,7 +443,7 @@ class BattleView extends React.Component {
 
         const usedEffect = this.state.battle.currentTurn.getNextEffect()
         this.state.battle.currentTurn.advance();
-        visualizeEffect(usedEffect);
+        visualizeEffect(usedEffect, this);
     }
 
     callNextEffectIconAction(userTurn, index) {

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -18,6 +18,7 @@ import CenterDiv from "./styled-components/CenterDiv";
 import {getCurrentUserId} from "../../../../storage/user/userData";
 import DesktopBackground from "./styled-components/DesktopBackground";
 import {battleFromData} from "../../../../api/data-models/battle/Battle";
+import {visualizeEffect} from "./effectsVisualizing";
 
 class BattleView extends React.Component {
 
@@ -442,8 +443,7 @@ class BattleView extends React.Component {
 
         const usedEffect = this.state.battle.currentTurn.getNextEffect()
         this.state.battle.currentTurn.advance();
-        // TODO: here call function doing particular effect for example damage, change card-order etc.
-        // executeEffect(usedEffect);
+        visualizeEffect(usedEffect);
     }
 
     callNextEffectIconAction(userTurn, index) {

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -547,6 +547,13 @@ class BattleView extends React.Component {
         this.props.showPostBattle();
     }
 
+    playersOpacityHandler = (isEnemy) => {
+        const stoppedOpacity = '50%'
+        const stoppedTurns = isEnemy ? this.state.battle.enemy.stoppedTurns : this.state.battle.user.stoppedTurns;
+
+        return stoppedTurns ? stoppedOpacity : '100%';
+    }
+
     render() {
         if (this.state.battle === undefined) return (<></>);
         return (
@@ -555,7 +562,7 @@ class BattleView extends React.Component {
                     <PopUp visible={this.props.visible} disableClose
                            setTranslateY={this.props.setTranslateY}>
                         <MainContainer>
-                            <FlexGapContainer setMargin={'10px 0 0 0'}>
+                            <FlexGapContainer setMargin={'10px 0 0 0'} opacity={this.playersOpacityHandler(true)}>
                                 <ColumnGapContainer gap={'0'}>
                                     <EnemyStateContainer setTranslateX={this.state.enemyStateContainerTranslateX}
                                                          hp={parseInt(this.state.battle.enemy.stats.hp)}
@@ -572,7 +579,7 @@ class BattleView extends React.Component {
                                 {this.getCompactCards(true)}
                             </FlexGapContainer>
                             <KuceInBattle visible={this.state.kuceInBattleVisible}/>
-                            <FlexGapContainer setMargin={'0 0 10px 0'}>
+                            <FlexGapContainer setMargin={'0 0 10px 0'} opacity={this.playersOpacityHandler(false)}>
                                 {/* User Compact Card! Particular Compact Card is visible if order === 1 */}
                                 {this.getCompactCards(false)}
                                 <ColumnGapContainer gap={'0'}>

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -631,7 +631,8 @@ class BattleView extends React.Component {
                             <PopUp visible={this.props.visible} disableClose
                                    setWidth={'100%'} setHeight={'100%'}
                                    setAlignment={'space-between'}>
-                                <FlexGapContainer gap={'10px'} setMargin={'32px 0 0 0'}>
+                                <FlexGapContainer gap={'10px'} setMargin={'32px 0 0 0'}
+                                                  opacity={this.playersOpacityHandler(true)}>
                                     <EnemyStateContainer setTranslateY={this.state.enemyStateContainerTranslateY}
                                                          hp={parseInt(this.state.battle.enemy.stats.hp)}
                                                          shield={parseInt(this.state.battle.enemy.stats.armour)}
@@ -642,7 +643,8 @@ class BattleView extends React.Component {
                                     </FlexGapContainer>
                                 </FlexGapContainer>
                                 <KuceInBattle visible={this.state.kuceInBattleVisible}/>
-                                <FlexGapContainer gap={'10px'} setMargin={'0 0 32px 0'}>
+                                <FlexGapContainer gap={'10px'} setMargin={'0 0 32px 0'}
+                                                  opacity={this.playersOpacityHandler(false)}>
                                     <FlexGapContainer gap={'10px'}>
                                         {this.getCompactCards(false)}
                                     </FlexGapContainer>

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/BattleView.js
@@ -498,7 +498,11 @@ class BattleView extends React.Component {
     callNextCardSequence() {
         setTimeout(() => {
             const userTurn = this.state.battle.isUsersTurn;
-            this.fullCardAction(userTurn);
+            if (this.state.battle.currentTurn.usedCardId)
+                this.fullCardAction(userTurn);
+            else
+                this.compactCardBackCall()
+
         }, nextStepAnimationDuration * 3);
     }
 

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/effectsVisualizing.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/effectsVisualizing.js
@@ -14,7 +14,9 @@ import {
     trueDamageEffectId
 } from "../../../../api/data-models/battle/EffectIds";
 
-export const visualizeEffect = (executedEffect) => {
+// TODO: remove this eslint disable later
+// eslint-disable-next-line no-unused-vars
+export const visualizeEffect = (executedEffect, component) => {
     switch (executedEffect.id) {
         case damageEffectId:
             break;

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/effectsVisualizing.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/BattleView/effectsVisualizing.js
@@ -1,0 +1,46 @@
+import {
+    blockNextCardEffectId,
+    buffExecuteTwoTimesEffectId,
+    buffNextCardDamageEffectId,
+    buffNextCardEffectId,
+    buffNextCardHealEffectId,
+    buffNextCardShieldEffectId,
+    damageEffectId,
+    healEffectId,
+    randomizeDeckEffectId,
+    shieldEffectId,
+    skipNextCardEffectId,
+    stopForOneTurnEffectId,
+    trueDamageEffectId
+} from "../../../../api/data-models/battle/EffectIds";
+
+export const visualizeEffect = (executedEffect) => {
+    switch (executedEffect.id) {
+        case damageEffectId:
+            break;
+        case trueDamageEffectId:
+            break;
+        case shieldEffectId:
+            break;
+        case randomizeDeckEffectId:
+            break;
+        case stopForOneTurnEffectId:
+            break;
+        case buffExecuteTwoTimesEffectId:
+            break;
+        case healEffectId:
+            break;
+        case blockNextCardEffectId:
+            break;
+        case buffNextCardEffectId:
+            break;
+        case buffNextCardDamageEffectId:
+            break;
+        case buffNextCardShieldEffectId:
+            break;
+        case buffNextCardHealEffectId:
+            break;
+        case skipNextCardEffectId:
+            break;
+    }
+}

--- a/WMIAdventure/frontend/src/js/components/global/molecules/FlexGapContainer/FlexGapContainer.js
+++ b/WMIAdventure/frontend/src/js/components/global/molecules/FlexGapContainer/FlexGapContainer.js
@@ -2,10 +2,12 @@ import React from 'react';
 import Container from './styled-components/Container';
 
 class FlexGapContainer extends React.Component {
+
     render() {
         return (
             <Container setMargin={this.props.setMargin} gap={this.props.gap} space={this.props.space}
-                       setWidth={this.props.setWidth} setHeight={this.props.setHeight} reverse={this.props.reverse}>
+                       setWidth={this.props.setWidth} setHeight={this.props.setHeight} reverse={this.props.reverse}
+                       opacity={this.props.opacity}>
                 {this.props.children}
             </Container>
         );

--- a/WMIAdventure/frontend/src/js/components/global/molecules/FlexGapContainer/styled-components/Container.js
+++ b/WMIAdventure/frontend/src/js/components/global/molecules/FlexGapContainer/styled-components/Container.js
@@ -10,6 +10,7 @@ const Container = styled.div`
   width: ${({setWidth}) => setWidth ? setWidth : 'auto'};
   height: ${({setHeight}) => setHeight ? setHeight : 'auto'};
   opacity: ${({opacity}) => opacity ? opacity : '100%'};
+  transition: opacity 0.5s ease-in-out;
 `;
 
 export default Container;

--- a/WMIAdventure/frontend/src/js/components/global/molecules/FlexGapContainer/styled-components/Container.js
+++ b/WMIAdventure/frontend/src/js/components/global/molecules/FlexGapContainer/styled-components/Container.js
@@ -9,6 +9,7 @@ const Container = styled.div`
   margin: ${({setMargin}) => setMargin ? setMargin : '0'};
   width: ${({setWidth}) => setWidth ? setWidth : 'auto'};
   height: ${({setHeight}) => setHeight ? setHeight : 'auto'};
+  opacity: ${({opacity}) => opacity ? opacity : '100%'};
 `;
 
 export default Container;


### PR DESCRIPTION
Polecam stworzyć sobie kartę która zatrzymuje nas / enemy na jedną turę do testów.

- Jeżeli user jest zatrzymany, to jego profil i karty mają opacity zmniejszone:
![Screenshot_20211129_161955](https://user-images.githubusercontent.com/11946540/143894572-d2c45e5f-5598-47a7-b822-f121f6eb3c36.jpg)
![Screenshot_20211129_162050](https://user-images.githubusercontent.com/11946540/143894618-f9a3c17b-a96b-40b7-b2ce-d422c28313b3.jpg)

- Jeżeli jesteśmy zablokowani, to nasze karty się nie wykonują (nie wysuwa się full card ani compact card na środek, po prostu tura jest dalej kontunuowana

- Jednej rzeczy nie udało mi się zrobić i olałbym to, mianowicie na mobilce przy wykonywaniu się efektu zatrzymania na jedną turę skierowanego w gracza, karta która jest na środku też się wyszarza. Calluje to jako best effort i tak bym to zostawił, bo nie jest jest easy fix (chyba że Wy macie pomysły jak to poprawić, to dawajcie)
![Screenshot_20211129_162043](https://user-images.githubusercontent.com/11946540/143894861-ef39d58a-13c8-4ae2-8803-fd477461ae3b.jpg)

- Poprawiłem błąd gdzie odejmowaliśmy counter zatrzymanych tur w tej samej turze co jest wykonywany efekt zatrzymania (edge case gdzie celem jest gracz). Sprawdzamy teraz czy jakakolwiek karta się w ogóle wykonała zeby taki counter odjąć - napisałem test

- Naprawiłem błąd z brakiem wyświetlania mocy buffów