### PR TITLE
#724 CardCreator renders in multiple stages

### DIFF
--- a/WMIAdventure/frontend/src/js/components/card-editor/molecules/CardChoose/CardChoose.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/molecules/CardChoose/CardChoose.js
@@ -2,7 +2,7 @@ import React from 'react';
 import TransparentBack from './styled-components/TransparentBack';
 import Ul from './styled-components/Ul';
 import Card from '../../atoms/Card';
-import { Transition } from 'react-transition-group';
+import {Transition} from 'react-transition-group';
 import Search from '../../../global/atoms/Search';
 
 /* Transition timeout values */
@@ -27,7 +27,7 @@ class CardChoose extends React.Component {
     }
 
     handleHiding = (event) => {
-        if(!this.state.listHover) {
+        if (!this.state.listHover) {
             this.props.hideCardChooseHandler(event);
             setTimeout(() => {
                 this.setState({searchInput: ''});
@@ -44,10 +44,10 @@ class CardChoose extends React.Component {
         return (
             <Transition in={this.props.showCardChoose} timeout={timeout}>
                 {state => (
-                    <TransparentBack transitionState={state} onClick={this.handleHiding}>
+                    <TransparentBack transitionState={state}>
                         <Ul onMouseEnter={this.hoverTrue}
                             onMouseLeave={this.hoverFalse}>
-                            <Search searchInput={this.state.searchInput} handleSearch={this.handleSearch} />
+                            <Search searchInput={this.state.searchInput} handleSearch={this.handleSearch}/>
                             {
                                 this.props.cardsFromAPI.map((card) => {
                                     return (
@@ -58,7 +58,7 @@ class CardChoose extends React.Component {
                                                   image={card.image}
                                                   searchInput={this.state.searchInput}
                                                   levels={card.levels}
-                                                  chosenCardHandler={this.props.chosenCardHandler} />
+                                                  chosenCardHandler={this.props.chosenCardHandler}/>
                                         </React.Fragment>
                                     );
                                 })

--- a/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/CardsCreator.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/CardsCreator.js
@@ -15,6 +15,7 @@ import CardProperties from '../CardProperties';
 import CardView from '../CardView';
 import Navbar from "../../../global/atoms/Navbar";
 import {getAllCards} from "../../../../storage/cards/cardStorage";
+import CardsAPIGateway from "../../../../api/gateways/CardsAPIGateway";
 
 class CardsCreator extends React.Component {
     state = {

--- a/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/CardsCreator.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/CardsCreator.js
@@ -24,7 +24,7 @@ class CardsCreator extends React.Component {
         cardSubject: '',
         cardTooltip: '',
         cardImage: null,
-
+        editorOpened: false,
         /**
          * If user uploads image, then cardImage is file object and can't be used to preview uploaded image, so this variable exists.
          */
@@ -90,7 +90,7 @@ class CardsCreator extends React.Component {
         if (this.props.creatorType === 'edit')
             this.setState({headerLabel: 'Edytowanie karty', showCardChoose: true});
         else if (this.props.creatorType === 'create')
-            this.setState({headerLabel: 'Nowa karta', showCardChoose: false});
+            this.setState({headerLabel: 'Nowa karta', showCardChoose: false, editorOpened: true});
 
         if (this.props.creatorType === 'edit') {
             CardsAPIGateway.getAllCards()
@@ -227,6 +227,7 @@ class CardsCreator extends React.Component {
             cardTooltip: tooltip,
             cardImage: image,
             cardImageURLPreview: image,
+            editorOpened: true
         });
 
         this.setLevelsListFromCard(levels);
@@ -367,7 +368,7 @@ class CardsCreator extends React.Component {
                 <Wrapper>
                     <Navbar backLink={'/cards-creator-start'} label={this.state.headerLabel}/>
                     <Main>
-                        {this.state.cardId ? this.renderEditPage() : null}
+                        {this.state.editorOpened ? this.renderEditPage() : null}
                     </Main>
                 </Wrapper>
                 <SendCardPopup show={this.state.showSendCardPopup}

--- a/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/CardsCreator.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/CardsCreator.js
@@ -307,6 +307,56 @@ class CardsCreator extends React.Component {
         this.setState({showCardView: false});
     }
 
+    renderEditPage() {
+        return (
+            <>
+                <CardDescribePreview cardName={this.state.cardName}
+                                     cardSubject={this.state.cardSubject}
+                                     cardTooltip={this.state.cardTooltip}
+                                     showDescribeInputsHandler={this.showDescribeInputsHandler}
+                                     cardImage={this.state.cardImageURLPreview}
+                />
+                <Form>
+                    <CardDescribeInputs updateDescribePreview={this.updateDescribePreview}
+                                        onCardImageChange={this.onCardImageChange}
+                                        show={this.state.showDescribeInputs}
+                                        hideDescribeInputsHandler={this.hideDescribeInputsHandler}
+                                        cardName={this.state.cardName}
+                                        cardSubject={this.state.cardSubject}
+                                        cardTooltip={this.state.cardTooltip}
+                                        cardImage={this.state.cardImageURLPreview}
+                    />
+                    <CardProperties creatorType={this.props.creatorType}
+                                    levelCostValues={this.state.levelCostValues}
+                                    levelsListFromCard={this.state.levelsListFromCard}
+                                    effectsFromApi={this.state.effectsFromApi}
+                                    chosenEffectsFromCard={this.state.chosenEffectsFromCard}
+                                    effectsToSend={this.state.effectsToSend}
+                                    levelCostValuesHandler={this.levelCostValuesHandler}
+                                    levelCostClearHandler={this.levelCostClearHandler}
+                                    levelCostResetHandler={this.levelCostResetHandler}
+                                    removeLevelHandler={this.removeLevelHandler}
+                                    setEffectsToSendHandler={this.setEffectsToSendHandler}
+                                    levelCreatedHandler={this.levelCreatedHandler}
+                    />
+                    <Div>
+                        <Button onClick={this.refreshPage} access show={this.props.creatorType}>
+                            Edytuj inną
+                        </Button>
+                        <Button show access={this.state.effectsToSend[0].length !== 0 ||
+                        this.state.effectsToSend[1].length !== 0 ||
+                        this.state.effectsToSend[2].length !== 0} onClick={this.showCardViewHandler}>
+                            Podgląd
+                        </Button>
+                        <Button type='submit' access onClick={this.showSendCardPopupHandler} show>
+                            Wyślij
+                        </Button>
+                    </Div>
+                </Form>
+            </>
+        )
+    }
+
     render() {
         return (
             <>
@@ -317,49 +367,7 @@ class CardsCreator extends React.Component {
                 <Wrapper>
                     <Navbar backLink={'/cards-creator-start'} label={this.state.headerLabel}/>
                     <Main>
-                        <CardDescribePreview cardName={this.state.cardName}
-                                             cardSubject={this.state.cardSubject}
-                                             cardTooltip={this.state.cardTooltip}
-                                             showDescribeInputsHandler={this.showDescribeInputsHandler}
-                                             cardImage={this.state.cardImageURLPreview}
-                        />
-                        <Form>
-                            <CardDescribeInputs updateDescribePreview={this.updateDescribePreview}
-                                                onCardImageChange={this.onCardImageChange}
-                                                show={this.state.showDescribeInputs}
-                                                hideDescribeInputsHandler={this.hideDescribeInputsHandler}
-                                                cardName={this.state.cardName}
-                                                cardSubject={this.state.cardSubject}
-                                                cardTooltip={this.state.cardTooltip}
-                                                cardImage={this.state.cardImageURLPreview}
-                            />
-                            <CardProperties creatorType={this.props.creatorType}
-                                            levelCostValues={this.state.levelCostValues}
-                                            levelsListFromCard={this.state.levelsListFromCard}
-                                            effectsFromApi={this.state.effectsFromApi}
-                                            chosenEffectsFromCard={this.state.chosenEffectsFromCard}
-                                            effectsToSend={this.state.effectsToSend}
-                                            levelCostValuesHandler={this.levelCostValuesHandler}
-                                            levelCostClearHandler={this.levelCostClearHandler}
-                                            levelCostResetHandler={this.levelCostResetHandler}
-                                            removeLevelHandler={this.removeLevelHandler}
-                                            setEffectsToSendHandler={this.setEffectsToSendHandler}
-                                            levelCreatedHandler={this.levelCreatedHandler}
-                            />
-                            <Div>
-                                <Button onClick={this.refreshPage} access show={this.props.creatorType}>
-                                    Edytuj inną
-                                </Button>
-                                <Button show access={this.state.effectsToSend[0].length !== 0 ||
-                                    this.state.effectsToSend[1].length !== 0 ||
-                                    this.state.effectsToSend[2].length !== 0} onClick={this.showCardViewHandler}>
-                                    Podgląd
-                                </Button>
-                                <Button type='submit' access onClick={this.showSendCardPopupHandler} show>
-                                    Wyślij
-                                </Button>
-                            </Div>
-                        </Form>
+                        {this.state.cardId ? this.renderEditPage() : null}
                     </Main>
                 </Wrapper>
                 <SendCardPopup show={this.state.showSendCardPopup}


### PR DESCRIPTION
Closes #724 

Przy wyborze edytora kart renderowaliśmy wszystkie komponenty z edytora jeszcze zanim wybraliśmy kartę, którą chcemy edytować. To sprawiało że na telefonie strasznie wolno ładował się edytor. 

Rozwiązałem to tak, że renderujemy komponenty z edytora dopiero jak wybierzemy kartę do edycji albo będziemy chcieli stworzyć nową.