### PR TITLE
#722 Effects are not cached in CardsCreator

### DIFF
--- a/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/CardsCreator.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/CardsCreator.js
@@ -14,7 +14,6 @@ import CardDescribePreview from '../../atoms/CardDescribePreview';
 import CardDescribeInputs from '../../atoms/CardDescribeInputs';
 import CardProperties from '../CardProperties';
 import CardView from '../CardView';
-import {getAllEffects} from "../../../../storage/effects/effectStorage";
 import Navbar from "../../../global/atoms/Navbar";
 
 class CardsCreator extends React.Component {
@@ -97,7 +96,7 @@ class CardsCreator extends React.Component {
                 .then(data => this.setState({cardsFromApi: data}))
                 .catch(error => console.log(error));
         }
-        getAllEffects()
+        CardsAPIGateway.getAllEffects()
             .then(data => this.setState({effectsFromApi: data}))
             .catch(error => console.log(error));
     }
@@ -351,8 +350,8 @@ class CardsCreator extends React.Component {
                                     Edytuj inną
                                 </Button>
                                 <Button show access={this.state.effectsToSend[0].length !== 0 ||
-                                    this.state.effectsToSend[1].length !== 0 ||
-                                    this.state.effectsToSend[2].length !== 0} onClick={this.showCardViewHandler}>
+                                this.state.effectsToSend[1].length !== 0 ||
+                                this.state.effectsToSend[2].length !== 0} onClick={this.showCardViewHandler}>
                                     Podgląd
                                 </Button>
                                 <Button type='submit' access onClick={this.showSendCardPopupHandler} show>


### PR DESCRIPTION
Closes #722 

Błąd polegał na tym, że po wejściu w edytor kart wszystkie efekty się cachowały. Jako, że edytor kart nie potrzebuje obrazka to działania, to przeglądarka nie zapisuje nigdzie tych obrazków. 
Jak potem wchodziliśmy w Battle i tam już obrazki są potrzebne, to przeglądarka sobie ich nie pobrała, przez co mieliśmy tylko suche urle które się nie ładowały, nie wiem dlaczego. Możliwe że to zachowanie zależy od przeglądarki.

Usunąłem cachowanie efektów w edytorze, tam po prostu za każdym razem requestujemy je z backendu. Wiem, że to mało optymalny fix, ale na teraz nie jestem w stanie wymyślić lepszego