### PR TITLE
W podglądzie karty w edytorze wartości liczbowe wyświetlane są już poprawnie

### DIFF
--- a/WMIAdventure/backend/WMIAdventure_backend/cards/businesslogic/description_generator/PowerDescription.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/cards/businesslogic/description_generator/PowerDescription.py
@@ -14,10 +14,9 @@ class PowerDescription:
     
     def _remove_trailing_zeros_in_float(self, number: float) -> str:
         text = str(number)
-        text = text.rstrip('0')
-        
-        # We may have a dot remaining to the left.
-        return text.rstrip(r'.')
+        if "." in text:
+            text = text.rstrip('0').rstrip(r'.')
+        return text
 
     def _get_power_range(self, power: float, range: float) -> tuple[float, float]:
         """


### PR DESCRIPTION
Closes #710 

Liczby kończące się na `0`, ale nie mające `.` miały usuwane zera. Np. `10` było przerabiane na `1`.

![image](https://user-images.githubusercontent.com/43492764/144909705-1ebf0797-4d31-4e2f-941d-346ab3785679.png)
