### PR TITLE
Możliwość inwalidacji cache ze względu na jego czas życia

### DIFF
--- a/WMIAdventure/frontend/src/js/storage/cache/cache.js
+++ b/WMIAdventure/frontend/src/js/storage/cache/cache.js
@@ -2,15 +2,16 @@
  * Get an item under a key. If such item does not exist, create a new one from data returned by callback.
  * @param {string} key
  * @param {function(*=): *} setCallback
+ * @param ttl Time for a key to live in seconds
  */
-export const getWithSetCallback = async (key, setCallback) => {
+export const getWithSetCallback = async (key, setCallback, ttl = 120) => {
     const cachedItem = get(key);
     if (cachedItem)
         return cachedItem
 
     const data = await setCallback();
     if (data === null || data === undefined) return data;
-    return set(key, data);
+    return set(key, data, ttl);
 }
 
 /**
@@ -19,19 +20,37 @@ export const getWithSetCallback = async (key, setCallback) => {
  */
 export const get = (key) => {
     const cachedItem = sessionStorage.getItem(key);
-    if (cachedItem)
-        return JSON.parse(cachedItem)
-    return null
+    if (!cachedItem)
+        return null;
+
+    const parsedItem = JSON.parse(cachedItem);
+    const now = new Date();
+
+    if (now.getTime() > parsedItem.expiry) {
+        sessionStorage.removeItem(key);
+        return null;
+    }
+    return parsedItem.value;
+
 }
 
 /**
  * Sets a value under a given key and return it.
  * @param key
  * @param obj
+ * @param ttl - time in seconds for a key to live. 2 minutes by default.
  */
-export const set = (key, obj) => {
+export const set = (key, obj, ttl = 120) => {
     if (obj) {
-        const val = JSON.stringify(obj)
+        const now = new Date();
+
+        const ttlInSeconds = ttl * 1000
+        const item = {
+            value: obj,
+            expiry: now.getTime() + ttlInSeconds
+        }
+
+        const val = JSON.stringify(item)
         sessionStorage.setItem(key, val);
         return obj;
     }

--- a/WMIAdventure/frontend/src/js/storage/cards/cardStorage.js
+++ b/WMIAdventure/frontend/src/js/storage/cards/cardStorage.js
@@ -2,6 +2,8 @@ import {cardKey, cardsKey} from "../localStorageKeys";
 import CardsAPIGateway from "../../api/gateways/CardsAPIGateway";
 import {get, getWithSetCallback} from "../cache/cache";
 
+const cacheCardsForSeconds = 600; // 10 minutes
+
 export const getCardById = async (id) => {
     const cachedCard = await getCardByIdFromCache(id);
     if (cachedCard)
@@ -11,7 +13,7 @@ export const getCardById = async (id) => {
         return await response.json();
     }
 
-    return await getWithSetCallback(cardKey(id), callback);
+    return await getWithSetCallback(cardKey(id), callback, cacheCardsForSeconds);
 }
 
 /**
@@ -45,7 +47,7 @@ export const getAllCards = async () => {
         return await CardsAPIGateway.getAllCards();
     }
 
-    return await getWithSetCallback(cardsKey, callback);
+    return await getWithSetCallback(cardsKey, callback, cacheCardsForSeconds);
 }
 
 export default {getCardById, getCardsFromDeck};

--- a/WMIAdventure/frontend/src/js/storage/effects/effectStorage.js
+++ b/WMIAdventure/frontend/src/js/storage/effects/effectStorage.js
@@ -2,6 +2,7 @@ import CardsAPIGateway from "../../api/gateways/CardsAPIGateway";
 import {get, getWithSetCallback, set} from "../cache/cache";
 import {effectKeys} from "../localStorageKeys";
 
+const cacheEffectsForSeconds = 9999999; // As long as possible
 /**
  * Returns list of all effects.
  * @returns {Promise<[]>}
@@ -15,10 +16,10 @@ export const getAllEffects = async () => {
 
         // We save array of effects ids in storage. Later we can iterate over this array and retrieve individual effects.
         effectsIds = allEffects.map((effect) => effect.id);
-        set(effectKeys.effectsIds, effectsIds);
+        set(effectKeys.effectsIds, effectsIds, cacheEffectsForSeconds);
 
         for (const effect of allEffects) {
-            set(effectKeys.effectKey(effect.id), effect);
+            set(effectKeys.effectKey(effect.id), effect, cacheEffectsForSeconds);
         }
     }
 
@@ -34,8 +35,7 @@ export const getAllEffects = async () => {
 
     if (effectsIds) {
         retrieveEffectsFromStorage();
-    }
-    else {
+    } else {
         await retrieveEffectsFromAPIAndSaveToStorage();
     }
 

--- a/WMIAdventure/frontend/src/js/storage/profiles/userProfileList.js
+++ b/WMIAdventure/frontend/src/js/storage/profiles/userProfileList.js
@@ -2,6 +2,8 @@ import {getWithSetCallback} from "../cache/cache";
 import {profileKey, userProfileKeys} from "../localStorageKeys";
 import UserProfilesAPIGateway from "../../api/gateways/UserProfilesAPIGateway";
 
+const cacheUsersForSeconds = 300 // 5 minutes;
+
 export const getAllUserProfiles = async () => {
     const callback = async () => {
         try {
@@ -13,7 +15,7 @@ export const getAllUserProfiles = async () => {
         }
     }
 
-    return await getWithSetCallback(userProfileKeys.profileList, callback);
+    return await getWithSetCallback(userProfileKeys.profileList, callback, cacheUsersForSeconds);
 }
 
 export const getUserById = async (id) => {
@@ -26,5 +28,5 @@ export const getUserById = async (id) => {
             return null
         }
     }
-    return await getWithSetCallback(profileKey(id), callback)
+    return await getWithSetCallback(profileKey(id), callback, cacheUsersForSeconds);
 }

--- a/WMIAdventure/frontend/src/js/storage/user/userData.js
+++ b/WMIAdventure/frontend/src/js/storage/user/userData.js
@@ -5,6 +5,8 @@ import UserProfilesAPIGateway from "../../api/gateways/UserProfilesAPIGateway";
 import {whoAmI} from "../../api/gateways/UsersAPIGateway";
 import {getUserById} from "../profiles/userProfileList";
 
+const cacheUserDataForSeconds = 3600; // One hour
+
 export const isLoggedIn = async () => {
     return !!await getCurrentUserId();
 }
@@ -26,7 +28,7 @@ export const getCurrentUserData = async () => {
         }
         return null;
     }
-    return await getWithSetCallback(userDataKeys.username, backendCallback);
+    return await getWithSetCallback(userDataKeys.username, backendCallback, cacheUserDataForSeconds);
 }
 
 export const getCurrentUserId = async () => {
@@ -36,7 +38,7 @@ export const getCurrentUserId = async () => {
             return who.id;
         return null;
     }
-    return await getWithSetCallback(userDataKeys.id, backendCallback);
+    return await getWithSetCallback(userDataKeys.id, backendCallback, cacheUserDataForSeconds);
 }
 
 export const getUsersDecks = async (userId) => {
@@ -48,7 +50,7 @@ export const getUsersDecks = async (userId) => {
         }
         return null
     }
-    return await getWithSetCallback(userDataKeys.userDecks, backendCall)
+    return await getWithSetCallback(userDataKeys.userDecks, backendCall, cacheUserDataForSeconds);
 }
 
 export const getCurrentUserDecks = async () => {


### PR DESCRIPTION
Closes #737

Zrobiłem taki myk, że teraz w każdym itemie cacha zapisujemy jego czas życia, który możemy podawać w parametrze.
Nie trzeba robić jakiś periodycznych zadań które będą inwalidowały cache, tylko przy pobieraniu elementu z cache sprawdzamy, czy nie jest już przedawniony.

Na razie ustawiłem takie timery dla danych elementów:
- Karty - żyją 10 minut, nie często karty będą się zmieniały, a jak już dodamy nowe karty do bazy no to użytkownicy te 10 minut mogą poczekać
- Efekty - najdłużej jak się da, nie widzę zebyśmy kiedykolwiek coś tutaj zmieniali
- Profile użytkowników - 5 minut. Jak ktoś nowy stworzy konto to będziemy chcieli to zobaczyć i wydaje mi się, że 5 minut to dobry timer. Dajcie znać co myślicie.
- Dane użytkownika - 1 godzina - tutaj chodzi o nasze dane takie jak nasze ID, nazwę użytkownika i nasz profil. Generalnie to tutaj będzie trzeba ręcznie inwalidować cache przy takich akcjach jak zmiana danych (obrazka, nazwy wyświetlanej) i przy modyfikacji decka