### PR TITLE
Deck edit all places

### DIFF
--- a/WMIAdventure/frontend/src/js/components/battle/atoms/TinyCards/TinyCards.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/TinyCards/TinyCards.js
@@ -6,33 +6,15 @@ import unknownIcon from '../../../../../assets/images/unknown.png';
 import Deck from "../../molecules/Deck";
 
 class TinyCards extends Deck {
-    constructor(props) {
-        super(props);
-        this.state = {
-            card1: null,
-            card2: null,
-            card3: null,
-            card4: null,
-            card5: null,
-        };
-    }
-
-    getImages = (i) => {
-        let contents = [];
-        for (const [, card] of Object.entries(this.state)) {
-            card ? contents.push(card.image) : contents.push(unknownIcon);
-        }
-        return contents[i];
-    }
-
     render() {
         return (
             <MainContainer setMargin={this.props.setMargin} gap={this.props.gap}>
                 {[...Array(5)].map(
                     (e, i) => {
+                        const cardImg = this.props.deck.cards[i].image
                         return (
                             <ImageContainer key={`cardImage-${i}`}>
-                                <CardImage src={this.getImages(i) ? this.getImages(i) : unknownIcon}/>
+                                <CardImage src={cardImg ? cardImg : unknownIcon}/>
                             </ImageContainer>
                         );
                     }

--- a/WMIAdventure/frontend/src/js/components/battle/molecules/Deck/Deck.js
+++ b/WMIAdventure/frontend/src/js/components/battle/molecules/Deck/Deck.js
@@ -4,61 +4,17 @@ import MainDiv from './styled-components/MainDiv';
 import Header from './styled-components/Header';
 import Div from './styled-components/Div';
 import CompactCardView from '../../../global/atoms/CompactCardView';
-import unknownIcon from '../../../../../assets/icons/upload_image_dark.svg';
-import {getCardById} from "../../../../storage/cards/cardStorage";
 
 class Deck extends React.Component {
 
-    state = {
-        card1: null,
-        card2: null,
-        card3: null,
-        card4: null,
-        card5: null,
-    }
-
-    setCardsStateFromDeckProps = () => {
-        if (this.props.deck === null || this.props.deck === undefined) return;
-
-        for (const [cardNumber, card] of Object.entries(this.props.deck)) {
-            if (card.id === null || card.id === undefined) continue;
-            getCardById(card.id)
-                .then(respCard => {
-                    if (respCard) {
-                        this.setState({
-                            [cardNumber]: {
-                                name: respCard.name,
-                                level: card.level,
-                                image: respCard.image ? respCard.image : unknownIcon
-                            }
-                        });
-                    }
-                });
-
-        }
-    }
-
-    componentDidMount() {
-        this.setCardsStateFromDeckProps();
-    }
-
-    propsChanged = (prevProps) => {
-        if (!prevProps.deck && !this.props.deck) return false;
-        if (!prevProps.deck && this.props.deck) return true;
-
-        return (this.props.deck.card1.id !== prevProps.deck.card1.id);
-    }
-
-    componentDidUpdate(prevProps) {
-        if (this.propsChanged(prevProps))
-            this.setCardsStateFromDeckProps();
-    }
-
-    cardPropertyHandler = (number, property) => {
-        const field = this.state[`card${number}`];
-        if (field === null) return;
-
-        return field[`${property}`];
+    renderCompactCardIdx(idx) {
+        const card = this.props.deck.cards[idx];
+        return (
+            <CompactCardView setWidth={'78px'} setHeight={'126px'} setMargin={'0'}
+                             setIconWidth={'48px'} setIconHeight={'48px'} decorationHeight={'16px'}
+                             cardName={card.name} cardImage={card.image} cardLevel={card.level}
+                             setIconMarginBottom={'8px'} shadow/>
+        )
     }
 
 
@@ -70,38 +26,13 @@ class Deck extends React.Component {
                 </Header>
                 <Div>
                     <FlexGapContainer gap={'10px'} setMargin={'0 0 10px 0'}>
-                        <CompactCardView setWidth={'78px'} setHeight={'126px'} setMargin={'0'}
-                                         setIconWidth={'48px'} setIconHeight={'48px'} decorationHeight={'16px'}
-                                         cardName={this.cardPropertyHandler(1, 'name')}
-                                         cardImage={this.cardPropertyHandler(1, 'image')}
-                                         cardLevel={this.cardPropertyHandler(1, 'level')}
-                                         setIconMarginBottom={'8px'} shadow/>
-                        <CompactCardView setWidth={'78px'} setHeight={'126px'} setMargin={'0'}
-                                         setIconWidth={'48px'} setIconHeight={'48px'} decorationHeight={'16px'}
-                                         cardName={this.cardPropertyHandler(2, 'name')}
-                                         cardImage={this.cardPropertyHandler(2, 'image')}
-                                         cardLevel={this.cardPropertyHandler(2, 'level')}
-                                         setIconMarginBottom={'8px'} shadow/>
-                        <CompactCardView setWidth={'78px'} setHeight={'126px'} setMargin={'0'}
-                                         setIconWidth={'48px'} setIconHeight={'48px'} decorationHeight={'16px'}
-                                         cardName={this.cardPropertyHandler(3, 'name')}
-                                         cardImage={this.cardPropertyHandler(3, 'image')}
-                                         cardLevel={this.cardPropertyHandler(3, 'level')}
-                                         setIconMarginBottom={'8px'} shadow/>
+                        {this.renderCompactCardIdx(0)}
+                        {this.renderCompactCardIdx(1)}
+                        {this.renderCompactCardIdx(2)}
                     </FlexGapContainer>
                     <FlexGapContainer gap={'10px'} setMargin={'0'}>
-                        <CompactCardView setWidth={'78px'} setHeight={'126px'} setMargin={'0'}
-                                         setIconWidth={'48px'} setIconHeight={'48px'} decorationHeight={'16px'}
-                                         cardName={this.cardPropertyHandler(4, 'name')}
-                                         cardImage={this.cardPropertyHandler(4, 'image')}
-                                         cardLevel={this.cardPropertyHandler(4, 'level')}
-                                         setIconMarginBottom={'8px'} shadow/>
-                        <CompactCardView setWidth={'78px'} setHeight={'126px'} setMargin={'0'}
-                                         setIconWidth={'48px'} setIconHeight={'48px'} decorationHeight={'16px'}
-                                         cardName={this.cardPropertyHandler(5, 'name')}
-                                         cardImage={this.cardPropertyHandler(5, 'image')}
-                                         cardLevel={this.cardPropertyHandler(5, 'level')}
-                                         setIconMarginBottom={'8px'} shadow/>
+                        {this.renderCompactCardIdx(3)}
+                        {this.renderCompactCardIdx(4)}
                     </FlexGapContainer>
                 </Div>
             </MainDiv>

--- a/WMIAdventure/frontend/src/js/components/battle/molecules/Deck/Deck.js
+++ b/WMIAdventure/frontend/src/js/components/battle/molecules/Deck/Deck.js
@@ -4,8 +4,12 @@ import MainDiv from './styled-components/MainDiv';
 import Header from './styled-components/Header';
 import Div from './styled-components/Div';
 import CompactCardView from '../../../global/atoms/CompactCardView';
+import ChangeDeckCard from "../../../profile/molecules/ChangeDeckCard";
 
 class Deck extends React.Component {
+    state = {
+        editorVisible: false,
+    }
 
     renderCompactCardIdx(idx) {
         const card = this.props.deck.cards[idx];
@@ -13,10 +17,29 @@ class Deck extends React.Component {
             <CompactCardView setWidth={'78px'} setHeight={'126px'} setMargin={'0'}
                              setIconWidth={'48px'} setIconHeight={'48px'} decorationHeight={'16px'}
                              cardName={card.name} cardImage={card.image} cardLevel={card.level}
-                             setIconMarginBottom={'8px'} shadow/>
+                             setIconMarginBottom={'8px'} shadow onClick={() => this.setEditorVisible(card)}/>
         )
     }
 
+    setEditorVisible = (card) => {
+        this.props.deck.setCurrentlyEditingCard(card);
+        this.setState({editorVisible: true});
+    }
+
+    closeEditor = () => {
+        this.setState({editorVisible: false});
+    }
+
+    renderEditComponent = () => {
+        if (!this.state.editorVisible)
+            return;
+
+        return (
+            <>
+                <ChangeDeckCard closeHandler={this.closeEditor} deck={this.props.deck}/>
+            </>
+        )
+    }
 
     render() {
         return (
@@ -35,6 +58,7 @@ class Deck extends React.Component {
                         {this.renderCompactCardIdx(4)}
                     </FlexGapContainer>
                 </Div>
+                {this.renderEditComponent()}
             </MainDiv>
         );
     }

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/SwipeProfile/SwipeProfile.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/SwipeProfile/SwipeProfile.js
@@ -7,13 +7,13 @@ import TinyUserProfile from '../../molecules/TinyUserProfile';
 import FlexGapContainer from '../../../global/molecules/FlexGapContainer/FlexGapContainer';
 import Media from 'react-media';
 import Deck from '../../molecules/Deck';
-import Edit from './styled-components/Edit';
 import {mobile} from '../../../../utils/globals';
 import FlexCenterContainer from './styled-components/FlexCenterContainer';
 import {getCurrentUserDecks} from "../../../../storage/user/userData";
 import UserInfo from "../../../global/atoms/UserInfo";
 import {EditableDeck, nullEditableDeck} from "../../../../api/data-models/battle/EditableDeck";
 import {cardsFromDeckData} from "../../../../api/data-models/battle/Card";
+import P from "./styled-components/P";
 
 class SwipeProfile extends React.Component {
 
@@ -92,9 +92,7 @@ class SwipeProfile extends React.Component {
                             </FlexCenterContainer>
                             <FlexCenterContainer>
                                 <Deck deck={this.state.deck}/>
-                                <Edit>
-                                    Edytuj
-                                </Edit>
+                                <P>Dotknij kartę aby zmodyfikować talię</P>
                             </FlexCenterContainer>
                         </>
                     </Article>

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/SwipeProfile/SwipeProfile.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/SwipeProfile/SwipeProfile.js
@@ -10,8 +10,10 @@ import Deck from '../../molecules/Deck';
 import Edit from './styled-components/Edit';
 import {mobile} from '../../../../utils/globals';
 import FlexCenterContainer from './styled-components/FlexCenterContainer';
-import {getUsersDecks} from "../../../../storage/user/userData";
+import {getCurrentUserDecks} from "../../../../storage/user/userData";
 import UserInfo from "../../../global/atoms/UserInfo";
+import {EditableDeck, nullEditableDeck} from "../../../../api/data-models/battle/EditableDeck";
+import {cardsFromDeckData} from "../../../../api/data-models/battle/Card";
 
 class SwipeProfile extends React.Component {
 
@@ -19,7 +21,7 @@ class SwipeProfile extends React.Component {
         hide: true,
         tinyDeckVisible: true,
         tinyDeckDisplay: true,
-        userDeck: null
+        deck: nullEditableDeck()
     }
 
     showHandler = () => {
@@ -37,16 +39,17 @@ class SwipeProfile extends React.Component {
         this.props.hideScroll();
     }
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.userId === this.props.userId) return;
+    async getDeck() {
+        const data = await getCurrentUserDecks();
+        if (!data)
+            return;
 
-        getUsersDecks(this.props.userId)
-            .then(resp => {
-                if (resp) {
-                    const attackerDeck = resp[0];
-                    this.setState({userDeck: attackerDeck});
-                }
-            });
+        const userSpecificCards = await cardsFromDeckData(data);
+        this.setState({deck: new EditableDeck(userSpecificCards)});
+    }
+
+    componentDidMount() {
+        this.getDeck()
     }
 
     hideHandler = () => {
@@ -71,7 +74,7 @@ class SwipeProfile extends React.Component {
                 <Div hide={this.state.hide}>
                     <TinyDeck
                         showHandler={this.showHandler}
-                        deck={this.state.userDeck}
+                        deck={this.state.deck}
                         tinyDeckVisible={this.state.tinyDeckVisible}
                         tinyDeckDisplay={this.state.tinyDeckDisplay}
                     />
@@ -88,7 +91,7 @@ class SwipeProfile extends React.Component {
                                 </FlexGapContainer>
                             </FlexCenterContainer>
                             <FlexCenterContainer>
-                                <Deck deck={this.state.userDeck}/>
+                                <Deck deck={this.state.deck}/>
                                 <Edit>
                                     Edytuj
                                 </Edit>

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/SwipeProfile/styled-components/P.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/SwipeProfile/styled-components/P.js
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const P = styled.p`
+  font-family: 'Roboto', sans-serif;
+  font-size: 12px;
+  font-weight: ${({theme}) => theme.weight.light};
+  color: ${({theme}) => theme.colors.darkGray};
+`;
+
+export default P;

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/TinyProfileDesktop/TinyProfileDesktop.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/TinyProfileDesktop/TinyProfileDesktop.js
@@ -9,6 +9,7 @@ import {getCurrentUserDecks} from "../../../../storage/user/userData";
 import UserInfo from "../../../global/atoms/UserInfo";
 import {EditableDeck, nullEditableDeck} from "../../../../api/data-models/battle/EditableDeck";
 import {cardsFromDeckData} from "../../../../api/data-models/battle/Card";
+import ChangeDeckCard from "../../../profile/molecules/ChangeDeckCard";
 
 class TinyProfileDesktop extends React.Component {
     state = {
@@ -29,6 +30,26 @@ class TinyProfileDesktop extends React.Component {
         this.getDeck()
     }
 
+    setEditorVisible = (card) => {
+        this.state.deck.setCurrentlyEditingCard(card);
+        this.setState({editorVisible: true});
+    }
+
+    closeEditor = () => {
+        this.setState({editorVisible: false});
+    }
+
+    renderEditComponent = () => {
+        if (!this.state.editorVisible)
+            return;
+
+        return (
+            <>
+                <ChangeDeckCard closeHandler={this.closeEditor} deck={this.state.deck}/>
+            </>
+        )
+    }
+
     renderDeck() {
         let key = 1;
         const components = []
@@ -41,7 +62,8 @@ class TinyProfileDesktop extends React.Component {
                                  setWidth={'90px'} setHeight={'150px'}
                                  setMargin={'0'} ownFontSize={'20px'}
                                  setIconWidth={'60px'} setIconHeight={'60px'}
-                                 decorationHeight={'18px'}/>
+                                 decorationHeight={'18px'}
+                                 onClick={() => this.setEditorVisible(card)}/>
             );
             key++;
         }
@@ -66,6 +88,7 @@ class TinyProfileDesktop extends React.Component {
                 <FlexGapContainer gap={'16px'}>
                     {this.renderDeck()}
                 </FlexGapContainer>
+                {this.renderEditComponent()}
             </Div>
         );
     }

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/TinyProfileDesktop/TinyProfileDesktop.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/TinyProfileDesktop/TinyProfileDesktop.js
@@ -10,6 +10,7 @@ import UserInfo from "../../../global/atoms/UserInfo";
 import {EditableDeck, nullEditableDeck} from "../../../../api/data-models/battle/EditableDeck";
 import {cardsFromDeckData} from "../../../../api/data-models/battle/Card";
 import ChangeDeckCard from "../../../profile/molecules/ChangeDeckCard";
+import P from "./styled-components/P";
 
 class TinyProfileDesktop extends React.Component {
     state = {
@@ -88,6 +89,8 @@ class TinyProfileDesktop extends React.Component {
                 <FlexGapContainer gap={'16px'}>
                     {this.renderDeck()}
                 </FlexGapContainer>
+
+                <P>Klinkij na kartę aby zmodyfikować talię</P>
                 {this.renderEditComponent()}
             </Div>
         );

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/TinyProfileDesktop/TinyProfileDesktop.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/TinyProfileDesktop/TinyProfileDesktop.js
@@ -5,68 +5,50 @@ import ColumnGapContainer from '../../../global/molecules/ColumnGapContainer';
 import FlexGapContainer from '../../../global/molecules/FlexGapContainer/FlexGapContainer';
 import CompactCardView from '../../../global/atoms/CompactCardView';
 import Container from './styled-components/Container';
-import {getCardById} from "../../../../storage/cards/cardStorage";
-import {getUsersDecks} from "../../../../storage/user/userData";
+import {getCurrentUserDecks} from "../../../../storage/user/userData";
 import UserInfo from "../../../global/atoms/UserInfo";
+import {EditableDeck, nullEditableDeck} from "../../../../api/data-models/battle/EditableDeck";
+import {cardsFromDeckData} from "../../../../api/data-models/battle/Card";
 
 class TinyProfileDesktop extends React.Component {
-    placeholderCard = {
-        name: ' ',
-        level: 1,
-        image: null
+    state = {
+        editorVisible: false,
+        deck: nullEditableDeck(),
     }
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            userId: null,
-            card1: this.placeholderCard,
-            card2: this.placeholderCard,
-            card3: this.placeholderCard,
-            card4: this.placeholderCard,
-            card5: this.placeholderCard,
-            fetchedCards: false
-        }
-    }
+    async getDeck() {
+        const data = await getCurrentUserDecks();
+        if (!data)
+            return;
 
-    getCards = () => {
-        if (!this.props.userId) return;
-        getUsersDecks(this.props.userId)
-            .then(deck => {
-                if (!deck) return;
-                const attackerDeck = deck[0] ? deck[0] : [];
-
-                for (const [cardNumber, card] of Object.entries(attackerDeck)) {
-                    if (card.id === null || card.id === undefined) continue;
-                    getCardById(card.id)
-                        .then(respCard => {
-                            if (respCard) {
-                                this.setState({
-                                    [cardNumber]: {
-                                        name: respCard.name,
-                                        level: card.level,
-                                        image: respCard.image
-                                    },
-                                    fetchedCards: true
-                                });
-
-                            }
-                        });
-                }
-            });
+        const userSpecificCards = await cardsFromDeckData(data);
+        this.setState({deck: new EditableDeck(userSpecificCards)});
     }
 
     componentDidMount() {
-        this.getCards()
+        this.getDeck()
     }
 
-    componentDidUpdate() {
-        if (this.props.userId && !this.state.fetchedCards)
-            this.getCards()
+    renderDeck() {
+        let key = 1;
+        const components = []
+        for (const card of this.state.deck.cards) {
+            components.push(
+                <CompactCardView key={`compactCard-${key}`}
+                                 cardName={card.name}
+                                 cardImage={card.image}
+                                 cardLevel={card.level}
+                                 setWidth={'90px'} setHeight={'150px'}
+                                 setMargin={'0'} ownFontSize={'20px'}
+                                 setIconWidth={'60px'} setIconHeight={'60px'}
+                                 decorationHeight={'18px'}/>
+            );
+            key++;
+        }
+        return (<>{components}</>);
     }
 
     render() {
-        const deckSize = 5;
         return (
             <Div>
                 <Container gap={'24px'}>
@@ -82,20 +64,7 @@ class TinyProfileDesktop extends React.Component {
                     </ColumnGapContainer>
                 </Container>
                 <FlexGapContainer gap={'16px'}>
-                    {Array.from({length: deckSize}, (_, i) => i + 1).map(
-                        i => {
-                            return (
-                                <CompactCardView key={`compactCard-${i}`}
-                                                 cardName={this.state[`card${i}`].name}
-                                                 cardImage={this.state[`card${i}`].image}
-                                                 cardLevel={this.state[`card${i}`].level}
-                                                 setWidth={'90px'} setHeight={'150px'}
-                                                 setMargin={'0'} ownFontSize={'20px'}
-                                                 setIconWidth={'60px'} setIconHeight={'60px'}
-                                                 decorationHeight={'18px'}/>
-                            );
-                        }
-                    )}
+                    {this.renderDeck()}
                 </FlexGapContainer>
             </Div>
         );

--- a/WMIAdventure/frontend/src/js/components/battle/organisms/TinyProfileDesktop/styled-components/P.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/TinyProfileDesktop/styled-components/P.js
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+
+const P = styled.p`
+  font-family: 'Roboto', sans-serif;
+  font-size: 12px;
+  text-align: center;
+  line-height: 24px;
+  width: 106px;
+  margin-left: 50px;
+  font-weight: ${({theme}) => theme.weight.light};
+  color: ${({theme}) => theme.colors.darkGray};
+`;
+
+export default P;

--- a/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/styled-components/Div.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/CompactCardView/styled-components/Div.js
@@ -39,6 +39,12 @@ const Div = styled.div`
   order: ${({cardIndexInDeck, battleOnDesktop}) => (cardIndexInDeck && battleOnDesktop) ? cardIndexInDeck : '0'};
   border: 2px solid ${({hasBuff, level, theme}) => hasBuff ? colorHandler(level, theme) : 'none'};
 
+  cursor: ${({onClick}) => onClick ? 'pointer' : 'default'};
+
+  &:hover {
+    transform: scale(${({onClick}) => onClick ? '1.05' : '1'});
+  }
+
   @media (min-width: ${({theme}) => theme.overMobile}px) {
     width: ${({setWidth}) => setWidth ? setWidth : '144px'};
     height: ${({setHeight}) => setHeight ? setHeight : '220px'};

--- a/WMIAdventure/frontend/src/js/components/global/atoms/FullCardView/styled-components/Article.js
+++ b/WMIAdventure/frontend/src/js/components/global/atoms/FullCardView/styled-components/Article.js
@@ -26,6 +26,12 @@ const Article = styled.article`
   transform: translate(${({hasBuff}) => hasBuff ? '-32px' : '0'},
   ${({setTranslateY}) => setTranslateY ? setTranslateY : '0'});
   transition: transform 0.5s ease-in-out;
+  
+  cursor: ${({onClick}) => onClick ? 'pointer' : 'default'};
+
+  &:hover {
+    transform: scale(${({onClick}) => onClick ? '1.05' : '1'});
+  }
 
   @media (min-width: ${({theme}) => theme.overMobile}px) {
     width: ${({setWidth}) => setWidth ? setWidth : '300px'};

--- a/WMIAdventure/frontend/src/js/pages/Profile/Profile.js
+++ b/WMIAdventure/frontend/src/js/pages/Profile/Profile.js
@@ -26,6 +26,7 @@ import MyDeck from "../../components/profile/molecules/MyDeck";
 import DeckHeader from "./styled-componets/DeckHeader";
 import PopUpProfile from "../../components/profile/organisms/PopUpProfile";
 import EditProfile from "../../components/profile/molecules/EditProfile";
+import P from "./styled-componets/P";
 
 class Profile extends React.Component {
 
@@ -144,6 +145,7 @@ class Profile extends React.Component {
                                     </ColumnGapContainer>
                                     <Line/>
                                     <MyDeck deck={this.state.deck}/>
+                                    <P>Dotknij kartę aby zmodyfikować talię</P>
                                 </ColumnGapContainer>
                                 <ColumnGapContainer gap={'10px'}>
                                     <ButtonWithIcon setWidth={'158px'} icon={editProfil}
@@ -197,6 +199,8 @@ class Profile extends React.Component {
                                     Twoja talia
                                 </DeckHeader>
                                 <MyDeck deck={this.state.deck}/>
+
+                                <P>Klinkij na kartę aby zmodyfikować talię</P>
                             </RightDeckContainer>
                         </MainDesktopContainer>
                         {

--- a/WMIAdventure/frontend/src/js/pages/Profile/styled-componets/P.js
+++ b/WMIAdventure/frontend/src/js/pages/Profile/styled-componets/P.js
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+const P = styled.p`
+  font-family: 'Roboto', sans-serif;
+  font-size: 12px;
+  font-weight: ${({theme}) => theme.weight.light};
+  color: ${({theme}) => theme.colors.darkGray};
+
+
+  @media (min-width: ${({theme}) => theme.overMobile}px) {
+    font-size: 20px;
+    color: ${({theme}) => theme.colors.whiteAlmost};
+  }
+`;
+
+export default P;


### PR DESCRIPTION
Closes #750

Udało mi się zrobić refactor dosyć prosto żeby podpiąć te edytory decków, ale mimo wszystko było trochę zmian więc dlatego jest tak dużo plików zmienionych.

Dodałem napisy w miejscach gdzie można edytować talię żeby użytkownicy wiedzieli że mogą tutaj klikać na krarty. Dodatkowo na desktopie jak najeżdżamy na karty które można edytować to mamy onHover.

Nie mamy dalej zaimplementowanego desktopa w DeckEdicie więc jak klikniemy na tych dekstopowych wiokach na kartę to się wszystko rozwala, ale ważne, ze w ogóle działa i taki jest cel tego PR.