### PR TITLE
Level display

### DIFF
--- a/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/businesslogic/experience/Experience.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/businesslogic/experience/Experience.py
@@ -13,8 +13,10 @@ class Experience:
     def __init__(self, exp=0):
         self.level = 0
         self.exp_required_to_level_up = 0
+        self.next_level_percent = 0
         self.exp = exp
         self._populate()
+        self._populate_level_percentage()
 
     def _populate(self):
         guessing_level = 1
@@ -27,3 +29,8 @@ class Experience:
                 return
 
             guessing_level += 1
+
+    def _populate_level_percentage(self):
+        begin_level_range = CachedLevelBoundaries.get_min_exp_for_level(self.level)
+        end_level_range = CachedLevelBoundaries.get_min_exp_for_level(self.level + 1)
+        self.next_level_percent = round(((self.exp - begin_level_range) / (end_level_range - begin_level_range)) * 100)

--- a/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/businesslogic/experience/tests/test_Experience.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/businesslogic/experience/tests/test_Experience.py
@@ -30,3 +30,22 @@ class ExperienceTestCase(unittest.TestCase):
         experience_obj = Experience(exp)
         expected_exp_required = abs(exp - level_to_exp(level + 1))
         self.assertEqual(experience_obj.exp_required_to_level_up, expected_exp_required)
+
+    def test_should_calculate_percentage_correctly(self):
+        exp = 5
+        # Next level is at 10
+        experience_obj = Experience(exp)
+        self.assertEqual(experience_obj.next_level_percent, 50)
+
+    def test_should_calculate_percentage_correctly_when_zero_exp(self):
+        exp = 0
+        # Next level is at 10
+        experience_obj = Experience(exp)
+        self.assertEqual(experience_obj.next_level_percent, 0)
+
+    def test_should_calculate_percentage_correctly_when_100_percent(self):
+        exp = 10
+        # Next level is at 10
+        experience_obj = Experience(exp)
+        # Should not return 100, because we are a level higher
+        self.assertEqual(experience_obj.next_level_percent, 0)

--- a/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/serializers.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/serializers.py
@@ -7,6 +7,12 @@ from .businesslogic.experience.Experience import Experience
 from .models import UserProfile, Deck, UserCard, UserDeck
 
 
+class UserStatsSerializer(serializers.Serializer):
+    exp = serializers.IntegerField()
+    level = serializers.IntegerField()
+    percentage = serializers.IntegerField(source='next_level_percent')
+
+
 class UserLevelSerializer(serializers.Field):
     def to_internal_value(self, data):
         pass

--- a/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/tests.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/tests.py
@@ -9,9 +9,10 @@ from battle.businesslogic.tests.Creator import Creator
 from cards.factories import create_card_with_effect
 from cards.models import Card, CardInfo, CardLevel
 from . import views
+from .businesslogic.experience.Experience import Experience
 from .factories import create_user_profile_with_deck, UserProfileFactory
 from .models import UserProfile, Semester, UserCard, Deck, UserDeck, UserStats
-from .serializers import UserDecksSerializer, DeckSerializer, UserProfileSerializer
+from .serializers import UserDecksSerializer, DeckSerializer, UserProfileSerializer, UserStatsSerializer
 from .signals import on_user_create
 
 
@@ -428,3 +429,13 @@ class UserDeckViewTestCase(TestCase):
 
         serializer = UserProfileSerializer(instance=profile)
         self.assertEqual(serializer.data.get('level', None), 1)
+
+    def test_should_serialize_full_level_data(self):
+        experience = Experience(5)
+        expected_exp = experience.exp
+        expected_level = experience.level
+        expected_percentage = experience.next_level_percent
+        serializer = UserStatsSerializer(instance=experience)
+        self.assertEqual(serializer.data.get('exp'), expected_exp)
+        self.assertEqual(serializer.data.get('level'), expected_level)
+        self.assertEqual(serializer.data.get('percentage'), expected_percentage)

--- a/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/urls.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/IngameUsers/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from .views import UserDecksView, PaginatedUsersView, UserView, UserDeckView
+from .views import UserDecksView, PaginatedUsersView, UserView, UserDeckView, UserLevelView
 
 urlpatterns = [
     path('', PaginatedUsersView.as_view(), name='user profiles'),
     path('<int:pk>/', UserView.as_view(), name='user profile'),
+    path('<int:pk>/level/', UserLevelView.as_view(), name='user level info'),
     path('<int:pk>/decks/', UserDecksView.as_view(), name='decks'),
     path('<int:pk>/decks/<int:deck_number>/', UserDeckView.as_view(), name='deck'),
 ]


### PR DESCRIPTION
Closes #796 

Mamy nowy widok pod `user-profiles/<id>/level/`. Zwraca nam takiego JSONa:
```json
{
    "exp": 23,
    "level": 3,
    "percentage": 30
}
```

`percentage` przyda się żeby pokazać użytkownikowi odpowiednio duży pasek z poziomem.

Jak będziemy chcieli robić #807 to można tutaj dodać jeszcze pole z expem do następnego poziomu.