### PR TITLE
Odbugowany OpponentSelected

### DIFF
--- a/WMIAdventure/frontend/src/js/components/battle/organisms/OpponentSelected/OpponentSelected.js
+++ b/WMIAdventure/frontend/src/js/components/battle/organisms/OpponentSelected/OpponentSelected.js
@@ -120,7 +120,6 @@ class OpponentSelected extends React.Component {
     }
 
     quickBattleRunHandler = () => {
-        this.props.closeUserPreviewHandler();
         this.props.kuceStartFight('Szybka Walka');
         fightWithUser(this.props.opponent.userId)
             .then(response => {
@@ -165,6 +164,7 @@ class OpponentSelected extends React.Component {
     }
 
     quickBattleCloseHandler = () => {
+        this.props.closeUserPreviewHandler();
         this.setState({
             postBattlePos: '-100vh',
             postBattleOpacity: '0'
@@ -187,7 +187,6 @@ class OpponentSelected extends React.Component {
     }
 
     onFightButton = () => {
-        this.props.closeUserPreviewHandler();
         this.props.kuceStartFight('Walka');
         fightWithUser(this.props.opponent.userId)
             .then(response => {
@@ -207,8 +206,6 @@ class OpponentSelected extends React.Component {
     }
     // method that run dynamic battle view
     battleViewRunHandler = () => {
-        this.props.closeUserPreviewHandler();
-
         this.props.kuceStopFight();
         this.setState({
             battleView: {visible: true, translateY: '-100vh', scale: '0'},

--- a/WMIAdventure/frontend/src/js/pages/BattleMode/BattleMode.js
+++ b/WMIAdventure/frontend/src/js/pages/BattleMode/BattleMode.js
@@ -96,9 +96,10 @@ class BattleMode extends React.Component {
         setTimeout(() => {
             this.setState({
                 userPreviewRun: false,
+                selectedUser: null,
             });
             this.forceUpdate();
-        }, 550);
+        }, 300);
     }
 
     hideScroll = () => {


### PR DESCRIPTION
Closes #865

Błąd ten powstawał przez to, że nie wyrzucaliśmy tego komponentu z DOMa po zamknięciu popupa. Jakieś dzikie staty wtedy się tam ustawiały i przez to transition nie działał tak jak trzeba.

Jedyny tradeoff jaki teraz się pojawił to to, że ten widok OpponentSelected będzie w tle cały czas, nawet na PostBattle. Jak zymkamy PostBattle to OpponentSelected zamyka się razem z nim