### PR TITLE
Nowy starter deck

### DIFF
--- a/WMIAdventure/backend/WMIAdventure_backend/utils/test_data/create_example_data.py
+++ b/WMIAdventure/backend/WMIAdventure_backend/utils/test_data/create_example_data.py
@@ -31,11 +31,30 @@ def get_or_create_example_card(name, tooltip, subject) -> Card:
 
 
 def get_or_create_example_deck_for_user(user: UserProfile):
-    card1 = get_or_create_example_card("Przykład 1", "1", "Programowanie Obiektowe")
-    card2 = get_or_create_example_card("Przykład 2", "2", "Programowanie Obiektowe")
-    card3 = get_or_create_example_card("Przykład 3", "3", "Programowanie Obiektowe")
-    card4 = get_or_create_example_card("Przykład 4", "4", "Programowanie Obiektowe")
-    card5 = get_or_create_example_card("Przykład 5", "5", "Programowanie Obiektowe")
+    card1 = get_or_create_example_card(
+        "BACI",
+        "Nigdy nie wiesz co się stanie.",
+        "Systemy operacyjne")
+    card2 = get_or_create_example_card(
+        "Bubble sort",
+        "Prosty, działa, tylko wolno",
+        "Algorytmy i struktury danych"
+    )
+    card3 = get_or_create_example_card(
+        "Udowodnij",
+        "Dobra defensywa",
+        "Wstęp do matematyki"
+    )
+    card4 = get_or_create_example_card(
+        "Microshell",
+        "Dobry projekt, ale nie zawsze działa tak jak chcemy",
+        "Systemy operacyjne"
+    )
+    card5 = get_or_create_example_card(
+        "C",
+        "Może i śmiga szybko, ale błędy są nieuniknione",
+        "Podstawy programowania"
+    )
 
     user_card1 = UserCard.objects.create(user_profile=user,
                                          card=card1)


### PR DESCRIPTION
Wymyśliłem taki startowy deck, żeby nie był za mocny.
- BACI
- Bubble sort
- Udowodnij
- Microshell
- C

Deck korzysta z `get_or_create` po nazwie. To wiążę się z małymi problemami w przypadku, gdy te karty zmienią nazwy, wtedy pojawią się duplikaty.

Domyślne efekty są takie same jak przykładowych kart, ale pojawią się one tylko wtedy, gdy w naszej bazie nie będzie w ogóle takich kart, bo musimy wtedy je stworzyć żeby uniknąć błędów. Obrazki też się nie tworzą. 

Zarówno na Azure i Produkcji te karty są już stworzone, dlatego zostaną pobrane z bazy z takimi efektami jakie są już w bazie. Warunkiem jest tylko ta sama nawa.

Na localhosćie możemy sobie dowolnie modyfikować te karty, jeżeli nie zmienimy nazwy to startowy deck będzie nadal korzystał z tych kart ze zaktualizowanymi danymi (obrazek, nowe efekty itp).

Closes #855