### PR TITLE
Fix redirecta przy "Edytuj inną" w edytorze kart

### DIFF
--- a/WMIAdventure/frontend/src/js/components/card-editor/molecules/CardChoose/CardChoose.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/molecules/CardChoose/CardChoose.js
@@ -27,6 +27,8 @@ class CardChoose extends React.Component {
     }
 
     handleHiding = (event) => {
+        if (!this.props.canHide)
+            return;
         if (!this.state.listHover) {
             this.props.hideCardChooseHandler(event);
             setTimeout(() => {
@@ -44,7 +46,7 @@ class CardChoose extends React.Component {
         return (
             <Transition in={this.props.showCardChoose} timeout={timeout}>
                 {state => (
-                    <TransparentBack transitionState={state}>
+                    <TransparentBack onClick={this.handleHiding} transitionState={state}>
                         <Ul onMouseEnter={this.hoverTrue}
                             onMouseLeave={this.hoverFalse}>
                             <Search searchInput={this.state.searchInput} handleSearch={this.handleSearch}/>

--- a/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/CardsCreator.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/CardsCreator.js
@@ -231,10 +231,19 @@ class CardsCreator extends React.Component {
             editorOpened: true
         });
 
-        this.setLevelsListFromCard(levels);
-        this.setLevelCostValuesFromCard(levels);
-        this.setChosenEffectsFromCard(levels);
-        this.hideCardChooseHandler(event);
+        this.setState({
+            levelsListFromCard: [],
+            levelCostValues: [undefined, undefined, undefined],
+            effectsToSend: [[], [], []],
+            chosenEffectsFromCard: [[], [], []],
+        })
+
+        setTimeout(() => {
+            this.setLevelsListFromCard(levels);
+            this.setLevelCostValuesFromCard(levels);
+            this.setChosenEffectsFromCard(levels);
+            this.hideCardChooseHandler(event);
+        }, 10);
     }
 
     setLevelsListFromCard = (levels) => {

--- a/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/CardsCreator.js
+++ b/WMIAdventure/frontend/src/js/components/card-editor/organisms/CardsCreator/CardsCreator.js
@@ -290,10 +290,6 @@ class CardsCreator extends React.Component {
         this.setState({showSendMessage: false});
     }
 
-    refreshPage = () => {
-        window.location.reload();
-    }
-
     commentInputHandler = (event) => {
         const keyName = event.target.name;
         let keyValue = event.target.value;
@@ -311,6 +307,11 @@ class CardsCreator extends React.Component {
     hideCardViewHandler = (event) => {
         event.preventDefault();
         this.setState({showCardView: false});
+    }
+
+    onEditOtherClick = (event) => {
+        event.preventDefault();
+        this.setState({showCardChoose: true});
     }
 
     renderEditPage() {
@@ -346,7 +347,7 @@ class CardsCreator extends React.Component {
                                     levelCreatedHandler={this.levelCreatedHandler}
                     />
                     <Div>
-                        <Button onClick={this.refreshPage} access show={this.props.creatorType}>
+                        <Button onClick={this.onEditOtherClick} access show={this.props.creatorType}>
                             Edytuj inną
                         </Button>
                         <Button show access={this.state.effectsToSend[0].length !== 0 ||
@@ -368,6 +369,7 @@ class CardsCreator extends React.Component {
             <>
                 <CardChoose showCardChoose={this.state.showCardChoose}
                             hideCardChooseHandler={this.hideCardChooseHandler}
+                            canHide={this.state.cardId}
                             cardsFromAPI={this.state.cardsFromApi}
                             chosenCardHandler={this.chosenCardHandler}/>
                 <Wrapper>


### PR DESCRIPTION
Closes #870

Zrobiłem to trochę inaczej niż było na początku. Przy wyborze tego przycisku stronka była reloadowana, a to powoduje przeniesienie na stronę główną.

Próbowałem na początku ogarnąć to odświeżanie, żeby dało się odświeżyć stronkę bez przekierowania do main page, ale za dużo czasu nad tym już spędzałem i mi nie wychodziło.

Alternatywnym rozwiązaniem była zmiana zachowania tego przycisku. Teraz po prostu pojawia się popup z listą wszystkich kart i jak wybierzemy którąkolwiek to po prostu stan nam się zmieni. Możemy ten popup zamknąć klikając poza nim.

Jak wchodzimy pierwszy raz w edytor to tego popupa nie możemy zamknąć.

Sprawdziłbym, czy wysyłanie kart na pewno działa jak trzeba po tej zmianie, bo tam jest bardzo rozbudowany stan i nie wiem, czy nie będzie trzeba robić większego cleanupu przy zmianie edytowanej karty