### PR TITLE
Paginacja na frontendzie

### DIFF
--- a/WMIAdventure/frontend/src/js/api/gateways/UserProfilesAPIGateway.js
+++ b/WMIAdventure/frontend/src/js/api/gateways/UserProfilesAPIGateway.js
@@ -6,15 +6,25 @@ import UserProfilesEndpoints from "../endpoints/UserProfilesEndpoints";
  * @returns {Promise<*>} Array of basic user info objects.
  */
 const getAllBasicUsersInfo = async () => {
-    const pageSize = 1000;
+    const pageSize = 15;
     let users = [];
     let resp = await RequestSender.get(UserProfilesEndpoints.main + `?pagesize=${pageSize}`)
         .then(resp => resp.json());
-    users.push.apply(users, resp.results);
+    let pageCounter = 1;
+    const appendPage = (pageNumber, hasNext, results) => {
+        users.push({
+            page: pageCounter,
+            hasNext: hasNext,
+            hasPrev: pageNumber !== 1,
+            results: results
+        });
+    }
+    appendPage(pageCounter, !!resp.next, resp.results)
     while (resp.next !== null) {
+        pageCounter++;
         resp = await RequestSender.get(resp.next)
             .then(resp => resp.json());
-        users.push.apply(users, resp.results);
+        appendPage(pageCounter, !!resp.next, resp.results);
     }
     return users;
 }

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/Pager/Pager.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/Pager/Pager.js
@@ -5,10 +5,10 @@ import MainDiv from "./styled-components/MainDiv";
 class Pager extends React.Component {
     render() {
         return (
-            <MainDiv>
-                <PageButton disabled={!this.props.previous}>&lt;</PageButton>
-                <PageButton>1</PageButton>
-                <PageButton disabled={!this.props.next}>&gt;</PageButton>
+            <MainDiv setMargin={this.props.setMargin}>
+                <PageButton disabled={!this.props.previous} onClick={this.props.onPrevious}>&lt;</PageButton>
+                <PageButton notClickable>{this.props.page}</PageButton>
+                <PageButton disabled={!this.props.next} onClick={this.props.onNext}>&gt;</PageButton>
             </MainDiv>
 
         );

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/Pager/styled-components/MainDiv.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/Pager/styled-components/MainDiv.js
@@ -8,8 +8,8 @@ const MainDiv = styled.div`
   justify-content: center;
   align-items: center;
   gap: 16px;
-  
-  margin: 16px 0 76px 0;
+
+  margin: ${({setMargin}) => setMargin ? setMargin : '16px 0 76px 0'};
 `
 
 export default MainDiv;

--- a/WMIAdventure/frontend/src/js/components/battle/atoms/Pager/styled-components/PageButton.js
+++ b/WMIAdventure/frontend/src/js/components/battle/atoms/Pager/styled-components/PageButton.js
@@ -15,7 +15,7 @@ const PageButton = styled.button`
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
   border-radius: 50%;
   border-style: none;
-  cursor: ${({disabled}) => disabled ? 'auto' : 'pointer'};
+  cursor: ${({disabled, notClickable}) => (disabled || notClickable) ? 'auto' : 'pointer'};
 
   /* Font */
   color: ${({theme, disabled}) => !disabled ? theme.colors.dark : theme.colors.light2};

--- a/WMIAdventure/frontend/src/js/pages/BattleMode/BattleMode.js
+++ b/WMIAdventure/frontend/src/js/pages/BattleMode/BattleMode.js
@@ -18,7 +18,7 @@ import Title from './styled-components/Title';
 import TinyProfileDesktop from '../../components/battle/organisms/TinyProfileDesktop';
 import {getCurrentUserData} from "../../storage/user/userData";
 import LoadingPopUp from "../../components/global/atoms/LoadingPopUp";
-import {getUserListPage} from "../../storage/profiles/userProfileList";
+import {getAllUserProfiles, getUserListPage} from "../../storage/profiles/userProfileList";
 import BasicUserData from "../../api/data-models/user/BasicUserData";
 import {DetailedUserData, nullDetailedUserData} from "../../api/data-models/user/DetailedUserData";
 import Pager from "../../components/battle/atoms/Pager";
@@ -54,7 +54,17 @@ class BattleMode extends React.Component {
     }
 
     async fetchAndFillProfiles(page = 1) {
-        const data = await getUserListPage(page);
+        console.log('fetching')
+        let data;
+        if (page === 0)
+            data = {
+                page: 1,
+                hasNext: false,
+                hasPrev: false,
+                results: await getAllUserProfiles(),
+            }
+        else
+            data = await getUserListPage(page);
         if (!data)
             return;
 
@@ -125,6 +135,10 @@ class BattleMode extends React.Component {
 
     handleSearch = (event) => {
         let keyValue = event.target.value;
+        if (keyValue.length > 0 && (this.state.users.hasNext || this.state.users.hasPrev))
+            this.fetchAndFillProfiles(0)
+        else if (keyValue.length === 0)
+            this.fetchAndFillProfiles(1)
         this.setState({searchInput: keyValue});
     }
 

--- a/WMIAdventure/frontend/src/js/pages/BattleMode/BattleMode.js
+++ b/WMIAdventure/frontend/src/js/pages/BattleMode/BattleMode.js
@@ -18,9 +18,10 @@ import Title from './styled-components/Title';
 import TinyProfileDesktop from '../../components/battle/organisms/TinyProfileDesktop';
 import {getCurrentUserData} from "../../storage/user/userData";
 import LoadingPopUp from "../../components/global/atoms/LoadingPopUp";
-import {getAllUserProfiles} from "../../storage/profiles/userProfileList";
+import {getUserListPage} from "../../storage/profiles/userProfileList";
 import BasicUserData from "../../api/data-models/user/BasicUserData";
 import {DetailedUserData, nullDetailedUserData} from "../../api/data-models/user/DetailedUserData";
+import Pager from "../../components/battle/atoms/Pager";
 
 class BattleMode extends React.Component {
     title = 'Tryb Battle';
@@ -52,15 +53,23 @@ class BattleMode extends React.Component {
         this.setState({loggedInUser: user});
     }
 
-    async fetchAndFillProfiles() {
-        const data = await getAllUserProfiles();
+    async fetchAndFillProfiles(page = 1) {
+        const data = await getUserListPage(page);
         if (!data)
             return;
 
         const users = [];
-        for (const user of data)
+        for (const user of data.results)
             users.push(new BasicUserData(user.user, user.displayedUsername, user.semester, user.image, user.level))
-        this.setState({users: users});
+
+        this.setState({
+            users: {
+                hasNext: data.hasNext,
+                hasPrev: data.hasPrev,
+                page: data.page,
+                results: users,
+            }
+        });
     }
 
     componentDidMount() {
@@ -135,7 +144,7 @@ class BattleMode extends React.Component {
     userListItemsRender = () => {
         return (
             <Ul scrollVisible={this.state.scrollVisible}>
-                {this.state.users ? this.state.users.map((elem) => {
+                {this.state.users.results ? this.state.users.results.map((elem) => {
                     if (elem.userId === this.state.loggedInUser.userId)
                         return null;
                     return (
@@ -165,6 +174,26 @@ class BattleMode extends React.Component {
         )
     }
 
+    nextUsersListPage = () => {
+        if (!this.state.users.hasNext) return;
+        this.fetchAndFillProfiles(this.state.users.page + 1)
+    }
+
+    prevUsersListPage = () => {
+        if (!this.state.users.hasPrev) return;
+        this.fetchAndFillProfiles(this.state.users.page - 1)
+    }
+
+    renderPaginator(isDesktop) {
+        if (!this.state.users) return null;
+        return (<Pager setMargin={isDesktop ? '16px 0 0 0' : null} page={this.state.users.page}
+                       next={this.state.users.hasNext}
+                       previous={this.state.users.hasPrev}
+                       onNext={this.nextUsersListPage}
+                       onPrevious={this.prevUsersListPage}
+        />)
+    }
+
     render() {
         return (
             <>
@@ -182,6 +211,7 @@ class BattleMode extends React.Component {
                                         handleSearch={this.handleSearch}/>
                             </SearchContainer>
                             {this.userListItemsRender()}
+                            {this.renderPaginator(false)}
                             <SwipeProfile user={this.state.loggedInUser}
                                           hideScroll={this.hideScroll} showScroll={this.showScroll}/>
                         </>
@@ -204,6 +234,7 @@ class BattleMode extends React.Component {
                                             handleSearch={this.handleSearch}/>
                                 </SearchContainer>
                                 {this.userListItemsRender()}
+                                {this.renderPaginator(true)}
                             </DesktopLeft>
                         </>
                     </Media>

--- a/WMIAdventure/frontend/src/js/pages/BattleMode/styled-components/Ul.js
+++ b/WMIAdventure/frontend/src/js/pages/BattleMode/styled-components/Ul.js
@@ -5,7 +5,7 @@ const Ul = styled.ul`
   max-width: 340px;
   overflow-y: scroll;
   list-style: none;
-  margin: 0 auto 92px;
+  margin: 0 auto;
   padding: 0 10px 10px;
   background-color: ${({theme}) => theme.colors.whiteAlmost};
   border-bottom-left-radius: 20px;
@@ -15,17 +15,18 @@ const Ul = styled.ul`
 
   scrollbar-width: ${({scrollVisible}) => scrollVisible ? 'thin' : 'none'};
   -ms-overflow-style: ${({scrollVisible}) => scrollVisible ? 'auto' : 'none'}; /* IE 10+ */
+
   ::-webkit-scrollbar {
     display: ${({scrollVisible}) => scrollVisible ? 'auto' : 'none'}; /* Chrome Safari */
   }
-  
-  @media(min-width: ${({theme}) => theme.overMobile}px) {
+
+  @media (min-width: ${({theme}) => theme.overMobile}px) {
     -ms-overflow-style: none; /* IE 10+ */
     scrollbar-width: none;
     ::-webkit-scrollbar {
       display: none; /* Chrome Safari */
     }
-    
+
     max-width: 514px;
     height: 100%;
     margin: 0;

--- a/WMIAdventure/frontend/src/js/storage/profiles/userProfileList.js
+++ b/WMIAdventure/frontend/src/js/storage/profiles/userProfileList.js
@@ -15,7 +15,8 @@ export const getAllUserProfiles = async () => {
         }
     }
 
-    return await getWithSetCallback(userProfileKeys.profileList, callback, cacheUsersForSeconds);
+    const cachePages = await getWithSetCallback(userProfileKeys.profileList, callback, cacheUsersForSeconds);
+    return cachePages.flatMap(item => item.results);
 }
 
 export const getUserById = async (id) => {

--- a/WMIAdventure/frontend/src/js/storage/profiles/userProfileList.js
+++ b/WMIAdventure/frontend/src/js/storage/profiles/userProfileList.js
@@ -4,7 +4,7 @@ import UserProfilesAPIGateway from "../../api/gateways/UserProfilesAPIGateway";
 
 const cacheUsersForSeconds = 300 // 5 minutes;
 
-export const getAllUserProfiles = async () => {
+export const getAllUserProfiles = async (flatten = true) => {
     const callback = async () => {
         try {
             const response = await UserProfilesAPIGateway.getAllBasicUsersInfo();
@@ -16,7 +16,12 @@ export const getAllUserProfiles = async () => {
     }
 
     const cachePages = await getWithSetCallback(userProfileKeys.profileList, callback, cacheUsersForSeconds);
-    return cachePages.flatMap(item => item.results);
+    return flatten ? cachePages.flatMap(item => item.results) : cachePages;
+}
+
+export const getUserListPage = async (pageNumber) => {
+    const allProfiles = await getAllUserProfiles(false);
+    return allProfiles.filter(page => page.page === pageNumber)[0];
 }
 
 export const getUserById = async (id) => {


### PR DESCRIPTION
Closes #928 

Zrobiłem to trochę głupio ale powinno rozwiązać problem.

Paginacja jest tak naprawdę na frontendzie teraz, bo i tak pobieramy najpierw wszystkich userów tylko po stronach. Generalnie problemu nie było na backendzie z tym że za dużo userów musimy pobrać tylko z tym, że na froncie lagowało. Ta decyzja wynikła z tego, że potrzebujemy mieć wyszukiwanie on-demand.