### PR TITLE
Frontend pobiera tylko aktualną stronę użytkowników z backendu

### DIFF
--- a/WMIAdventure/frontend/src/js/api/gateways/UserProfilesAPIGateway.js
+++ b/WMIAdventure/frontend/src/js/api/gateways/UserProfilesAPIGateway.js
@@ -1,32 +1,21 @@
 import RequestSender from "../RequestSender";
 import UserProfilesEndpoints from "../endpoints/UserProfilesEndpoints";
 
-/**
- * Returns list of all users with their basic information.
- * @returns {Promise<*>} Array of basic user info objects.
- */
-const getAllBasicUsersInfo = async () => {
-    const pageSize = 15;
-    let users = [];
-    let resp = await RequestSender.get(UserProfilesEndpoints.main + `?pagesize=${pageSize}`)
-        .then(resp => resp.json());
-    let pageCounter = 1;
-    const appendPage = (pageNumber, hasNext, results) => {
-        users.push({
-            page: pageCounter,
-            hasNext: hasNext,
-            hasPrev: pageNumber !== 1,
-            results: results
-        });
-    }
-    appendPage(pageCounter, !!resp.next, resp.results)
-    while (resp.next !== null) {
-        pageCounter++;
-        resp = await RequestSender.get(resp.next)
-            .then(resp => resp.json());
-        appendPage(pageCounter, !!resp.next, resp.results);
-    }
-    return users;
+const defaultPageSize = 15;
+
+const formatPage = (pageNumber, hasNext, results) => {
+    return {
+        page: pageNumber,
+        hasNext: hasNext,
+        hasPrev: pageNumber !== 1,
+        results: results
+    };
+}
+
+const getBasicUserInfoPage = async (pageNumber) => {
+    const resp = await RequestSender.get(UserProfilesEndpoints.main + `?pagesize=${defaultPageSize}&page=${pageNumber}`)
+    const json = await resp.json();
+    return formatPage(pageNumber, !!json.next, json.results);
 }
 /**
  * Gets given user's decks from API.
@@ -64,6 +53,6 @@ const upgradeCard = (userId, cardId) => {
 }
 
 export default {
-    getAllBasicUsersInfo, getUserDecks, getUserById, updateUsersDeck, getUserLevelData, getUserCards,
-    upgradeCard
+    getUserDecks, getUserById, updateUsersDeck, getUserLevelData, getUserCards,
+    upgradeCard, getBasicUserInfoPage
 };

--- a/WMIAdventure/frontend/src/js/storage/profiles/userProfileList.js
+++ b/WMIAdventure/frontend/src/js/storage/profiles/userProfileList.js
@@ -1,27 +1,43 @@
-import {getWithSetCallback, set} from "../cache/cache";
+import {get, getWithSetCallback, set} from "../cache/cache";
 import {profileKey, userProfileKeys} from "../localStorageKeys";
 import UserProfilesAPIGateway from "../../api/gateways/UserProfilesAPIGateway";
 
 const cacheUsersForSeconds = 300 // 5 minutes;
 
 export const getAllUserProfiles = async (flatten = true) => {
-    const callback = async () => {
-        try {
-            const response = await UserProfilesAPIGateway.getAllBasicUsersInfo();
-            return await response;
-        } catch (errors) {
-            console.log(errors);
-            return null
-        }
+    let pageNumber = 1;
+    let page = await getUserListPage(pageNumber);
+    const results = [page];
+    while (page.hasNext) {
+        pageNumber++;
+        page = await getUserListPage(pageNumber)
+        results.push(page);
     }
-
-    const cachePages = await getWithSetCallback(userProfileKeys.profileList, callback, cacheUsersForSeconds);
-    return flatten ? cachePages.flatMap(item => item.results) : cachePages;
+    return flatten ? results.flatMap(item => item.results) : results;
 }
 
 export const getUserListPage = async (pageNumber) => {
-    const allProfiles = await getAllUserProfiles(false);
-    return allProfiles.filter(page => page.page === pageNumber)[0];
+    const callback = async () => {
+        try {
+            return await UserProfilesAPIGateway.getBasicUserInfoPage(pageNumber);
+        } catch (errors) {
+            console.log(errors);
+            return null;
+        }
+    }
+    const allUsersPaginatedCache = await get(userProfileKeys.profileList);
+    const allUsersPaginated = allUsersPaginatedCache ? allUsersPaginatedCache : [];
+    const pageFromCache = allUsersPaginated ? allUsersPaginated.filter(page => page.page === pageNumber)[0] : null;
+    if (pageFromCache)
+        return pageFromCache;
+
+    const pageFromBackend = await callback();
+    if (!pageFromBackend)
+        return null;
+    allUsersPaginated.push(pageFromBackend);
+    await set(userProfileKeys.profileList, allUsersPaginated, cacheUsersForSeconds);
+    return pageFromBackend;
+
 }
 
 export const getUserById = async (id, forceUpdate = true) => {


### PR DESCRIPTION
- Po wejściu w Battle pobieramy tylko pierwszą stronę użytkowników z backendu (jeden request)
- Przejście na każdą kolejną stronę calluje backend (od razu strony są cachowane)
- Jak chcemy wyszukać użytkowników po nazwie to pobieramy najpierw wszystkie strony (kilka requestów). Potem wszystko jest zacachowane więc działa szybko.